### PR TITLE
Codex/fix quick tunnel oauth callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ bun run src/index.ts start --tunnel
 Quick Tunnel sign-in uses the registered `https://app.repoyeti.com/oauth/callback` only to return
 the OAuth response to the current daemon. Dashboard and Git traffic still go directly through the
 Cloudflare tunnel, including when you choose the temporary `*.trycloudflare.com` address.
+If that callback announcement fails during startup, RepoYeti retries it three times with bounded
+backoff. Login remains at a safe 503 while recovery is in progress and asks for a restart only after
+those retries are exhausted.
 
 Prefer a prebuilt copy? Grab your platform from
 [Releases](https://github.com/LunarWerxs/RepoYeti/releases). On Windows, download

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ To reach it from your phone (opens a Cloudflare tunnel and prints a QR code):
 bun run src/index.ts start --tunnel
 ```
 
+Quick Tunnel sign-in uses the registered `https://app.repoyeti.com/oauth/callback` only to return
+the OAuth response to the current daemon. Dashboard and Git traffic still go directly through the
+Cloudflare tunnel, including when you choose the temporary `*.trycloudflare.com` address.
+
 Prefer a prebuilt copy? Grab your platform from
 [Releases](https://github.com/LunarWerxs/RepoYeti/releases). On Windows, download
 `repoyeti-windows-x64.exe` and run it directly. The dashboard is embedded in the executable; there

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,10 +22,11 @@
 > case), and **Phase 6 (Tauri tray)** is deferred — the CLI binary + phone browser is the whole product.
 > The only thing between "built" and a live remote login is a single owner-gated end-to-end sign-in.
 >
-> **⚠️ Update since v1 — the tunnel/shim design in §2 & §7 is SUPERSEDED.** RepoYeti now runs a
-> **named Cloudflare tunnel** (`app.repoyeti.com`) and the daemon uses its **own**
-> `<origin>/oauth/callback` — there is no shim (`shim/` is dead reference code). The shipped design
-> and runbook are in **§15 (Remote access)**.
+> **Current remote-login design.** RepoYeti supports named tunnels and rotating Quick Tunnels.
+> Quick Tunnels authorize against the registered `https://app.repoyeti.com/oauth/callback`; the
+> relay resolves a signed-announcement id and returns only `code` and `state` to the current
+> daemon's `/oauth/finish`. Stable and loopback origins use their own callback directly. The relay
+> never proxies dashboard traffic. See **§7** and **§15**.
 
 ---
 
@@ -78,7 +79,7 @@ If that loop works over HTTPS from a cellular connection with no port forwarding
 | **Git engine** | **`simple-git`** over the system `git` binary | Reuses the user's installed, optimized git. Its per-call `env` option maps *directly* onto `GIT_SSH_COMMAND` / `GIT_AUTHOR_*` injection. No JS git reimplementation to trust. |
 | **HTTP framework** | **Hono** | Tiny, TS-native. Its middleware model makes auth **structural** — a single `app.use()` gates the whole router, so you *cannot* add an unauthenticated route by accident. |
 | **Storage** | **`bun:sqlite`**, WAL mode, `synchronous=NORMAL` | Only store that survives concurrent writers (watcher + API + git ops). One file: `repoyeti.db`. Retry on `SQLITE_BUSY`; fall back to `journal_mode=DELETE` if WAL won't open (Windows AV). |
-| **Tunnel** | **`cloudflared` quick tunnel** (free, rotating) **+ a fixed redirect shim** | Daemon stays zero-config on a free auto tunnel; a tiny **stable shim** (Cloudflare Worker `*.workers.dev` — recommended — or Pages / GitHub Pages) is the registered OAuth redirect and bounces login back to the daemon's current URL (§7). No domain, no ngrok. Tunnel client bundled as a pinned binary. A stable *dashboard* URL comes later, once you own a domain. |
+| **Tunnel** | **`cloudflared` quick or named tunnel** + stable OAuth callback for Quick Tunnels | Quick Tunnels stay zero-config and rotating; the relay returns OAuth to their announced origin without proxying the dashboard. Named tunnels use their stable callback directly. Tunnel client bundled as a pinned binary. |
 | **Auth** | **"Sign in with Connections"** — public OIDC (AEGIS) at `accounts.connections.icu`; daemon verifies the login token and trusts one owner `sub` | Stand-alone relying party using connections.icu's **public** OAuth — like "Log in with Google." No shared secret, no Connections-repo coupling, no homegrown password/PIN. See §7. |
 | **Transport / sync** | **SSE** daemon→phone, **REST** phone→daemon | v2 decided this. SSE auto-reconnects through cloudflared with no WebSocket upgrade; maps cleanly onto the event-driven watcher. Commands are request/response → REST. |
 | **Frontend** | **Vue 3 + Vite**, PWA, **embedded in the binary**; **import pre-built libraries, minimal hand-written UI** | Static files bundled at `bun --compile` time; daemon serves them — no second server. **Owner directive: lean on smart pre-built libs, write minimal UI to maintain.** Stack: **reka-ui** (shadcn-vue–style component kit, `src/components/ui/`) · **Tailwind v4** (`@tailwindcss/vite`) · **@vueuse/core** (composables — `useEventSource` handles SSE+reconnect, `useColorMode`, `useLocalStorage`) · **@formkit/auto-animate** (zero-config list/card transitions — solves "no layout shift on SSE updates" for free) · **@lucide/vue** icons · **vue-sonner** toasts · **Pinia** state · **vite-plugin-pwa** (auto manifest + service worker). |
@@ -267,8 +268,8 @@ outside SQLite.
 | `GET` | `/api/identities` | list | — |
 | `POST` `PUT` `DELETE` | `/api/identities[/:id]` | CRUD | PAT → keychain, never DB |
 | `GET` | `/api/events` | SSE stream | session cookie |
-| `GET` | `/oauth/login` | start "Sign in with Connections" (PKCE; `state` embeds daemon URL) | unauth → redirects to AEGIS via the shim |
-| `GET` | `/oauth/finish` | shim bounces here: code → token → JWKS verify → set session | checks owner `sub` |
+| `GET` | `/oauth/login` | start "Sign in with Connections" (PKCE; signed `state` binds origin, callback, relay id) | returns 503 until a Quick Tunnel callback route is announced |
+| `GET` | `/oauth/finish` | stable callback returns here: code → token → JWKS verify → set session | checks state, PKCE and owner `sub` |
 | `GET` | `/api/auth/me` | current session → `{ ok, sub, email }` | session cookie |
 | `POST` | `/api/auth/logout` | clear daemon session | session cookie |
 
@@ -335,49 +336,35 @@ RepoYeti is registered once as a **third-party OAuth app** (relying party) → i
    that browser/device (a `__Host-` cookie or short-lived token — standard relying-party behavior; the
    IdP authenticates, the app keeps the session). Refresh tokens keep it alive without re-login.
 
-### Login return = a fixed redirect "shim" — **DECIDED** (keeps the daemon on the free tunnel)
+### Login return through the stable callback
 
-> **⚠️ SUPERSEDED (kept for design history).** This shim squared a *rotating* tunnel URL with a fixed
-> OAuth redirect. RepoYeti has since moved to a **named Cloudflare tunnel** with a stable host
-> (`app.repoyeti.com`), so the daemon registers and uses its **own** `/oauth/callback` directly and
-> the shim is retired. The shipped design + runbook is in **§15 (Remote access)**; the text below
-> documents the original rotating-tunnel approach for reference.
+OAuth requires an exact registered redirect URI, while a free Quick Tunnel receives a new
+`*.trycloudflare.com` hostname at every start. RepoYeti registers
+`https://app.repoyeti.com/oauth/callback` and uses the existing signed relay announcement to find
+the current daemon without making the relay a dashboard proxy.
 
-The login page must return to a **registered, stable** redirect URI — but the daemon sits on a free,
-**rotating** quick-tunnel URL (AEGIS is redirect-based PKCE; no device-code flow exists). Squaring this
-**without buying a domain or running ngrok**: register a tiny **fixed redirect shim** (a free, stable
-edge URL you already have) and have it **bounce the login back to the daemon's current address.**
+Flow (daemon-side PKCE — the browser never holds tokens):
 
-Flow (daemon-side PKCE — the phone never handles tokens):
-1. Phone opens the daemon, taps "Sign in with Connections" → `GET /oauth/login` on the daemon.
-2. The daemon makes PKCE + a signed `state` that **embeds its own current tunnel URL**, and redirects
-   the phone to `accounts.connections.icu/oauth/authorize?…&redirect_uri=<SHIM>&state=…`.
-3. AEGIS authenticates the user → redirects the phone to the **shim** (`<SHIM>?code&state`).
-4. The shim reads `state`, checks the embedded daemon URL matches an **allowed pattern**, and
-   **302-redirects** the phone to `<daemon-current-url>/oauth/finish?code&state`.
-5. The daemon (`/oauth/finish`) verifies `state` (HMAC + CSRF nonce), exchanges `code` + its PKCE
-   `code_verifier` at `/oauth/token` (with `redirect_uri=<SHIM>`), verifies the `id_token` via the
-   **public JWKS**, checks the owner `sub`, and sets a `__Host-` session. Done.
+1. A Quick Tunnel announces `(relay id, current HTTPS origin, timestamp)` with Ed25519 during startup.
+2. `/oauth/login` resolves that ready route, creates PKCE, and signs state containing the nonce,
+   browser origin, exact redirect URI, and relay id. Until the announcement succeeds it returns 503
+   before contacting Connections.
+3. Connections returns `code` and `state` to `https://app.repoyeti.com/oauth/callback`.
+4. The Worker extracts only the relay id from state. It does not validate the daemon-owned HMAC and
+   never trusts an origin supplied by the request; it resolves a previously signed HTTPS destination
+   from KV and redirects only `code` and `state` to `<origin>/oauth/finish`.
+5. The daemon verifies the HMAC and nonce, exchanges the code using the exact redirect URI signed at
+   login plus its in-memory PKCE verifier, verifies the `id_token`, checks the owner, and sets the
+   session cookie. Legacy local states without an explicit redirect retain origin-based completion.
 
-**The only thing that must be stable + registered is the shim** — pick a free one you already have:
-- **Cloudflare Worker** (`https://repoyeti-auth.<account>.workers.dev`) — *recommended*: server-side 302,
-  validates the target host, no client JS, free, stable, **no custom domain**. ~30 lines; I can deploy it.
-- **Cloudflare Pages** (`https://<proj>.pages.dev`) or **GitHub Pages** (`https://<user>.github.io/…`) —
-  same idea as a tiny static page that reads `state` and redirects in-browser.
+The Worker can observe the transient authorization code, but PKCE prevents it from redeeming that
+code without the verifier. Callback responses use `no-store`. A forged state cannot make the Worker
+an open redirect because only an existing relay id selects a destination, and the daemon rejects a
+foreign or tampered state at `/oauth/finish`.
 
-**Security:** the `code` is **PKCE-bound** to the daemon's `code_verifier` (held server-side) and
-single-use, so intercepting it at the shim is useless; `state` is HMAC-signed and CSRF-checked by the
-daemon; the shim only forwards to daemon URLs matching an allowed pattern (no open redirect). The shim
-sees a transient, unusable code and nothing else.
-
-**Upgrade path:** once you own a domain, give the daemon a stable URL, register its own `/oauth/callback`
-directly, and the shim disappears (the *dashboard* URL stops rotating too).
-
-**Desktop fallback (Path B):** register `http://127.0.0.1:<port>/oauth/callback` and log in once at the
-machine — no shim, no tunnel — after which the phone is trusted.
-
-RepoYeti stays **stand-alone** throughout — it only ever calls the public `accounts.connections.icu/oauth/*`
-URLs; the shim is a dumb bounce on a free host, not a coupling to Connections.
+Loopback, named tunnels, and other non-Quick-Tunnel origins keep the direct
+`<origin>/oauth/callback` flow. Selecting the direct Cloudflare address disables only the stable
+dashboard URL; the one startup announcement required for OAuth still occurs.
 
 ### What an attacker with only the tunnel URL can do
 
@@ -647,14 +634,14 @@ repoyeti/
 ├─ web/                      # Vue 3 + Vite + Tailwind PWA
 │  ├─ src/ … (App, RepoCard, IdentitySelector, sse client)
 │  └─ vite.config.ts         # build → embedded static assets
-├─ shim/                     # OAuth redirect shim — now DEAD reference code (named tunnel + own /oauth/callback)
+├─ relay/                    # stable address + Quick Tunnel OAuth callback Worker
 ├─ vendor/cloudflared/       # pinned per-platform binaries
 └─ scripts/build.ts          # vite build → bun --compile per target
 ```
 
 The daemon is the **primary artifact**; `web/` builds into it; `vendor/cloudflared/` ships with it;
-`shim/` is retired (the named tunnel + the daemon's own `/oauth/callback` replaced it — see
-§15, Remote access); a future `tray/` (Tauri) would spawn the same binary unchanged.
+`relay/` contains the separately deployed redirect Worker used by stable links and Quick Tunnel
+OAuth return routing (see §15); a future `tray/` (Tauri) would spawn the same binary unchanged.
 `scripts/check-boundaries.ts` enforces the layering: `read ⊥ service`, `vcs ⊥ service`, `cli ⊥
 service/read/git`, and the MCP core/tools/backend touch the service only through their adapters.
 
@@ -668,11 +655,10 @@ service/read/git`, and the MCP core/tools/backend touch the service only through
   Studio path** — RepoYeti is a stand-alone relying party that only calls the public
   `accounts.connections.icu/oauth/*` URLs and verifies tokens via the public JWKS; it shares no secret
   with and imports nothing from the Connections repo. (Owner directive: public API, auth only, stand-alone.)
-- **DECIDED: free quick tunnel + a fixed redirect shim** (§7). The daemon stays zero-config on the free
-  rotating tunnel; a tiny stable shim (Cloudflare Worker `*.workers.dev`, recommended — or Pages/GitHub
-  Pages) is the registered OAuth redirect and bounces login back to the daemon, so the **phone logs in
-  directly** with no domain and no ngrok. PKCE + signed `state` keep the bounce safe. The *dashboard* URL
-  still rotates until a real domain is bought (then the shim is dropped).
+- **Quick Tunnels use the stable relay callback** (§7). The daemon announces its current HTTPS origin
+  with Ed25519 once per tunnel startup; the Worker resolves only that id and returns `code` + `state`
+  to `/oauth/finish`. PKCE and daemon-signed state complete the trust boundary. This announcement is
+  required even when the owner displays the direct Cloudflare address.
 - **Bun, not Node** — single-binary compile + built-in SQLite kills the worst Windows packaging pain.
 - **Tauri deferred to last** — the CLI binary + phone browser is the whole product.
 - **"Behind" is intentionally stale** — never auto-fetch on watch events.
@@ -689,17 +675,14 @@ Connections" (public OIDC). It imports nothing from the Connections repo. To lig
 1. **A registered RepoYeti OAuth app.** Create a "Sign in with Connections" app → yields a public
    **`client_id`** (and, if registered confidential, a `client_secret` that stays only on the daemon).
    Scopes: `openid profile email`.
-2. **The redirect URI** = the fixed **shim** URL (§7), e.g. `https://repoyeti-auth.<account>.workers.dev/cb`
-   (Cloudflare Worker, recommended) or a `*.pages.dev` / `*.github.io` page. **This is the only stable URL
-   that gets registered;** the daemon itself stays on the free rotating tunnel. (Optionally also register
-   `http://127.0.0.1:<port>/oauth/callback` for the Path-B desktop fallback.)
+2. **Registered redirect URIs:** `https://app.repoyeti.com/oauth/callback` for Quick Tunnels and the
+   appropriate loopback callback for local login. Named/custom-domain clients may additionally
+   register their own stable callback.
 3. **The trusted owner identity** — the `sub` (or email) RepoYeti should accept. Get it from
    `/oauth/userinfo` after a test login, or from the owner's account record. → daemon config/keychain.
-4. **The redirect shim (free; I can build + deploy it).** A ~30-line **Cloudflare Worker** (or static
-   Pages/GitHub page) that reads `state`, validates the daemon URL against an allowed pattern, and 302s
-   the login back to the daemon. Lives on a free `*.workers.dev` / `*.pages.dev` / `*.github.io` URL —
-   **no custom domain, not connections.icu's zone.** I can write + deploy the Worker via the Cloudflare
-   API. It's dropped entirely once you own a domain and the daemon registers its own callback.
+4. **The relay Worker.** Deploy `relay/worker.js` with KV and `/oauth/callback` support before a daemon
+   release that depends on it. The same signed announcement identity serves stable links and OAuth;
+   the callback never accepts a free-form destination from `state`.
 
 That's it — no AWS Secrets Manager entry, no Connections-repo change, no shared M2M secret. Everything
 the daemon needs (issuer, client_id, redirect, scopes) is public OIDC config; the only sensitive item
@@ -1088,16 +1071,13 @@ model; the only diff-specific tool, claw-compactor, is Python and can't live in 
 
 ---
 
-## 15. Remote access — named Cloudflare tunnel (runbook)
+## 15. Remote access — Quick and named Cloudflare tunnels
 
 
-> **TL;DR.** RepoYeti is reachable from a phone at **`https://app.repoyeti.com`** via a **named
-> Cloudflare tunnel** (not the old rotating, DNS-blocked `*.trycloudflare.com` quick tunnel). The
-> tunnel + DNS were provisioned **through the Connections vault** (no raw Cloudflare token ever
-> touched this machine). Login is done **the right way** — the daemon registers and uses its **own**
-> `/oauth/callback`, and the old redirect "shim" Worker is **deleted**. The Cloudflare layer is
-> verified; the only thing not yet runtime-proven is a live end-to-end sign-in (needs the daemon
-> running + one real login).
+> **TL;DR.** Owners may choose RepoYeti's stable address, a direct rotating
+> `*.trycloudflare.com` address, or a named tunnel on their own domain. Every Quick Tunnel uses
+> `https://app.repoyeti.com/oauth/callback` only for the OAuth return; named and loopback origins
+> complete directly. Dashboard traffic is never proxied by the relay.
 
 ---
 
@@ -1136,18 +1116,22 @@ isn't currently listening — which itself proves the ingress is correct).
 - **UI:** the Remote-access modal overflow (long URL pushing the copy button off the card) was a CSS-grid
   `min-width:auto` trap — fixed with `min-w-0` on the link block in `web/src/components/RemoteAccess.vue`.
 
-### Login — the right way (no shim)
-The old design used a **rotating** tunnel URL, so OAuth (which needs a fixed registered redirect) used a tiny
-"shim" Worker that bounced the login back to the daemon's current address. **With a stable domain that's
-obsolete.** Now:
+### Login callback selection
+
 - **IdP registration** (Connections `developer_app_registrations`, a registered public `client_id`):
   `redirect_uris = [ https://app.repoyeti.com/oauth/callback , http://127.0.0.1:7171/oauth/callback ]`.
   (The previous entry was malformed — `…/cb%20and`, old `gitmob-auth` name — and would have failed login.)
-- **Daemon** (`src/auth.ts`): `/oauth/login` sends `redirect_uri = <its own origin>/oauth/callback`;
-  `/oauth/callback` exchanges with the same value, derived from the **HMAC-signed `state`** (so it can't be
-  tampered). The IdP allow-list + the signed origin double-gate against open redirects.
-- **Shim retired:** the `gitmob-auth` Worker (it was never re-deployed under the new name) was **deleted** from
-  the Lunawerx Cloudflare account. `shim/` in this repo is now dead reference code.
+- **Quick Tunnel startup** (`src/runtime.ts`): announces the generated HTTPS origin to the callback
+  relay, even when stable-address forwarding is disabled. Login stays at 503 until that announcement
+  succeeds.
+- **Daemon login** (`src/auth.ts`): signs the initiating origin, exact redirect URI, nonce, and relay
+  id into state. `/oauth/finish` exchanges the code with exactly that redirect URI and the in-memory
+  PKCE verifier. Old local states without the redirect field remain accepted.
+- **Worker callback** (`relay/worker.js`): extracts only the relay id, resolves its Ed25519-announced
+  HTTPS origin from KV, and forwards only `code` and `state`. It can observe the transient code but
+  cannot redeem it without the verifier.
+- **Direct completion:** named/custom-domain and loopback origins keep
+  `<origin>/oauth/callback`; no relay lookup is needed.
 
 ### Headless agents — an optional Bearer API token (no browser needed)
 A **remote or headless AI agent** can't complete the browser-based OIDC dance. For that case the
@@ -1163,22 +1147,19 @@ owner can mint an **optional API token** and the agent authenticates with a Bear
   signed-in owner *or* the explicit token. The token is purely additive, for the headless case.
 
 ### To bring it fully live
-1. Run RepoYeti with **remote access on** (it reads `~/.repoyeti/config.json` and runs the named-tunnel
-   connector itself; `cloudflared` is installed).
-2. **Sign in once** over `app.repoyeti.com` to claim ownership (a request over the tunnel always requires the
-   owner session — the security invariant). This is the one step not yet runtime-verified.
+1. Run RepoYeti with **remote access on** using the RepoYeti address, direct Cloudflare address, or a
+   configured named tunnel.
+2. **Sign in once** to claim ownership. The complete Worker/daemon/PKCE/session journey is covered by
+   integration tests; a live IdP login remains a release smoke test.
 
 ### Security notes
 - A request arriving over the tunnel **always** requires a signed-in owner, in any mode (loopback can "continue
   local"). Enabling remote refuses until an owner is claimed (no stranger races TOFU on a fresh tunnel).
-- The named-tunnel host is a normal `repoyeti.com` record — **not** on any trycloudflare blocklist.
+- A named-tunnel host avoids networks that block `trycloudflare.com`; Quick Tunnel addressing cannot.
 
 ### Open
-- **Live sign-in not yet proven** (needs the daemon running). If the IdP rejects the redirect URI, it's an app-
-  registration cache TTL — re-try shortly.
-- **Google Cloud** (used elsewhere via the operator) still needs a re-connect for a fresh token — unrelated to
-  this tunnel; see the Connections doc §8.
-- Daemon code edits (`auth.ts`, `config.ts`, `tunnel.ts`, `runtime.ts`) are in the working tree.
+- **Live-provider smoke test:** after Worker-first rollout, verify one real login for each supported
+  address mode. This repository's automated suite uses a simulated standards-compatible IdP.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -347,8 +347,9 @@ Flow (daemon-side PKCE — the browser never holds tokens):
 
 1. A Quick Tunnel announces `(relay id, current HTTPS origin, timestamp)` with Ed25519 during startup.
 2. `/oauth/login` resolves that ready route, creates PKCE, and signs state containing the nonce,
-   browser origin, exact redirect URI, and relay id. Until the announcement succeeds it returns 503
-   before contacting Connections.
+   browser origin, exact redirect URI, and relay id. A failed startup announcement is retried after
+   1, 3, and 10 seconds. Until one succeeds, login returns 503 before contacting Connections; after
+   the bounded retries are exhausted, the page asks the owner to restart RepoYeti.
 3. Connections returns `code` and `state` to `https://app.repoyeti.com/oauth/callback`.
 4. The Worker extracts only the relay id from state. It does not validate the daemon-owned HMAC and
    never trusts an origin supplied by the request; it resolves a previously signed HTTPS destination

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -346,10 +346,14 @@ the current daemon without making the relay a dashboard proxy.
 Flow (daemon-side PKCE — the browser never holds tokens):
 
 1. A Quick Tunnel announces `(relay id, current HTTPS origin, timestamp)` with Ed25519 during startup.
+   A successful response must declare `oauth-callback-v1`, proving that the same Worker which
+   accepted the route also implements the registered callback. `/health` exposes the same capability.
 2. `/oauth/login` resolves that ready route, creates PKCE, and signs state containing the nonce,
    browser origin, exact redirect URI, and relay id. A failed startup announcement is retried after
    1, 3, and 10 seconds. Until one succeeds, login returns 503 before contacting Connections; after
-   the bounded retries are exhausted, the page asks the owner to restart RepoYeti.
+   the bounded retries are exhausted, the page asks the owner to restart RepoYeti. Missing,
+   malformed, or unknown capability declarations are terminal instead: login returns an
+   update-required 503 immediately because retrying cannot upgrade a deployed Worker.
 3. Connections returns `code` and `state` to `https://app.repoyeti.com/oauth/callback`.
 4. The Worker extracts only the relay id from state. It does not validate the daemon-owned HMAC and
    never trusts an origin supplied by the request; it resolves a previously signed HTTPS destination
@@ -681,9 +685,10 @@ Connections" (public OIDC). It imports nothing from the Connections repo. To lig
    register their own stable callback.
 3. **The trusted owner identity** — the `sub` (or email) RepoYeti should accept. Get it from
    `/oauth/userinfo` after a test login, or from the owner's account record. → daemon config/keychain.
-4. **The relay Worker.** Deploy `relay/worker.js` with KV and `/oauth/callback` support before a daemon
-   release that depends on it. The same signed announcement identity serves stable links and OAuth;
-   the callback never accepts a free-form destination from `state`.
+4. **The relay Worker.** `relay/worker.js` implements `/oauth/callback` and declares
+   `oauth-callback-v1` through `/health` and successful `/announce` responses. The same signed
+   identity serves stable links and OAuth, but an older Worker can still operate `/r/:id` while
+   Quick Tunnel login remains safely blocked.
 
 That's it — no AWS Secrets Manager entry, no Connections-repo change, no shared M2M secret. Everything
 the daemon needs (issuer, client_id, redirect, scopes) is public OIDC config; the only sensitive item
@@ -1124,13 +1129,15 @@ isn't currently listening — which itself proves the ingress is correct).
   (The previous entry was malformed — `…/cb%20and`, old `gitmob-auth` name — and would have failed login.)
 - **Quick Tunnel startup** (`src/runtime.ts`): announces the generated HTTPS origin to the callback
   relay, even when stable-address forwarding is disabled. Login stays at 503 until that announcement
-  succeeds.
+  succeeds and its response declares `oauth-callback-v1`. Missing, malformed, or unknown capability
+  sets are terminally incompatible and do not consume transient retry delays.
 - **Daemon login** (`src/auth.ts`): signs the initiating origin, exact redirect URI, nonce, and relay
   id into state. `/oauth/finish` exchanges the code with exactly that redirect URI and the in-memory
   PKCE verifier. Old local states without the redirect field remain accepted.
 - **Worker callback** (`relay/worker.js`): extracts only the relay id, resolves its Ed25519-announced
   HTTPS origin from KV, and forwards only `code` and `state`. It can observe the transient code but
-  cannot redeem it without the verifier.
+  cannot redeem it without the verifier. `/health` and successful `/announce` responses advertise
+  `oauth-callback-v1` so callers can inspect protocol compatibility.
 - **Direct completion:** named/custom-domain and loopback origins keep
   `<origin>/oauth/callback`; no relay lookup is needed.
 
@@ -1150,17 +1157,13 @@ owner can mint an **optional API token** and the agent authenticates with a Bear
 ### To bring it fully live
 1. Run RepoYeti with **remote access on** using the RepoYeti address, direct Cloudflare address, or a
    configured named tunnel.
-2. **Sign in once** to claim ownership. The complete Worker/daemon/PKCE/session journey is covered by
-   integration tests; a live IdP login remains a release smoke test.
+2. **Sign in once** to claim ownership. Integration tests cover the Worker/daemon/PKCE/session
+   journey with a simulated standards-compatible IdP.
 
 ### Security notes
 - A request arriving over the tunnel **always** requires a signed-in owner, in any mode (loopback can "continue
   local"). Enabling remote refuses until an owner is claimed (no stranger races TOFU on a fresh tunnel).
 - A named-tunnel host avoids networks that block `trycloudflare.com`; Quick Tunnel addressing cannot.
-
-### Open
-- **Live-provider smoke test:** after Worker-first rollout, verify one real login for each supported
-  address mode. This repository's automated suite uses a simulated standards-compatible IdP.
 
 ---
 

--- a/docs/STABLE_ADDRESS.md
+++ b/docs/STABLE_ADDRESS.md
@@ -36,6 +36,10 @@ announces the current tunnel to `app.repoyeti.com` once at startup so the regist
 return `code` and `state` to `/oauth/finish`. The hosted service does not proxy the dashboard or
 implicitly enable the stable RepoYeti address.
 
+If the startup announcement is rejected temporarily—for example because the host clock has just
+been corrected—RepoYeti retries after 1, 3, and 10 seconds. The sign-in page remains unavailable
+during those retries and recommends restarting only if every attempt fails.
+
 ## Custom domain
 
 If you own a domain on Cloudflare, a named tunnel serves RepoYeti at a hostname you control, such

--- a/docs/STABLE_ADDRESS.md
+++ b/docs/STABLE_ADDRESS.md
@@ -31,6 +31,11 @@ It needs no account or domain, but it changes when RepoYeti restarts. Existing s
 bookmarks that contain the old address then stop working. Choose this when you specifically prefer
 Cloudflare's temporary address over RepoYeti's stable front door.
 
+This choice changes the address shown to visitors, not the OAuth registration. RepoYeti still
+announces the current tunnel to `app.repoyeti.com` once at startup so the registered callback can
+return `code` and `state` to `/oauth/finish`. The hosted service does not proxy the dashboard or
+implicitly enable the stable RepoYeti address.
+
 ## Custom domain
 
 If you own a domain on Cloudflare, a named tunnel serves RepoYeti at a hostname you control, such

--- a/relay/README.md
+++ b/relay/README.md
@@ -11,6 +11,8 @@ person you sent it to gets a DNS failure that reads as *"your link is wrong"* ra
 address moved"* — and you only find out when they tell you.
 
 The relay gives each daemon one URL that never changes and forwards to wherever it currently lives.
+It also provides RepoYeti's registered OAuth callback for rotating Quick Tunnels. That callback is
+a narrow return route, not a dashboard proxy.
 
 ## What it is not
 
@@ -26,6 +28,11 @@ Optional collaboration presence does not use KV. The collaborator resolves the i
 then sends authenticated AES-256-GCM snapshots straight to the owner's tunnel. If a quick tunnel
 moves, `/resolve/:id` supplies its new origin. This keeps realtime updates out of the relay's
 storage and request budget.
+
+The OAuth return is similarly narrow: `GET /oauth/callback` reads only the relay id from the signed
+`state`, resolves the origin already registered by an Ed25519 announcement, and redirects only
+`code` and `state` to `<currentOrigin>/oauth/finish`. It never accepts a destination URL from the
+request. Missing, malformed, unknown, corrupt, or non-HTTPS destinations fail without a redirect.
 
 ## Why the relay never sees a share token
 
@@ -54,6 +61,10 @@ feature into a phishing kit. Ids are 128-bit random, so squatting an unused id i
 attack. Announces also carry a timestamp and are rejected outside a five-minute window, so a
 captured one cannot be replayed later.
 
+The Worker can observe the short-lived OAuth authorization code while forwarding it. PKCE binds
+that code to a verifier held only in daemon memory, so the Worker cannot exchange it for tokens.
+Both callback errors and redirects use `Cache-Control: no-store`.
+
 Covered by `tests/relay-worker.test.ts`, which runs the real Worker against a fake KV — including
 the case where an attacker signs correctly with their *own* key and offers a replacement public key.
 
@@ -70,11 +81,11 @@ Self-hosting on your own domain? Change the `routes` entry in `wrangler.toml` to
 cert. A bare `workers.dev` hostname works too (`workers_dev = true`, no custom domain) — it's
 already stable, which is the only property this service requires.
 
-**If you own a domain, you probably don't want this at all.** Put the daemon on a NAMED TUNNEL
+**If you own a domain, you do not need the relay for routing.** Put the daemon on a NAMED TUNNEL
 instead (`tunnel.hostname` + a connector token in the daemon config): your address is then stable
 AND resolves on networks that block `trycloudflare.com`, because visitors never touch trycloudflare.
-The relay only forwards to a quick tunnel, so it fixes rotation and not blocking. It exists for
-people without a domain.
+Quick Tunnels still use its registered OAuth callback even when the owner chooses the direct
+Cloudflare address; named tunnels complete OAuth directly.
 
 ## Deploy
 
@@ -115,15 +126,16 @@ Leave `identity` alone — the daemon mints its own keypair on first announce an
 Deleting it registers a NEW id next time, which breaks every link already handed out; turning the
 relay off in Settings deliberately keeps it for that reason.
 
-**Off by default, deliberately.** A self-hosted tool should not phone anywhere unless asked. When
-enabled, the only thing that ever leaves the machine is `(id, origin, timestamp, signature)`: no
-repository names, no paths, no tokens.
+Choosing the direct Cloudflare address disables the stable `/r/:id` address, but a Quick Tunnel
+still sends one signed announcement at startup for OAuth return routing. The announcement contains
+only `(id, origin, timestamp, signature)`: no repository names, paths, or share tokens.
 
 ## Endpoints
 
 | Method | Path            | Purpose                                                        |
 | ------ | --------------- | -------------------------------------------------------------- |
 | `POST` | `/announce`     | Daemon publishes its current origin (signed).                    |
+| `GET`  | `/oauth/callback` | Resolve relay id from signed state; forward only `code` + `state`. |
 | `GET`  | `/r/:id`        | Forwarding page; re-attaches the URL fragment client-side.       |
 | `GET`  | `/r/:id/<path>` | Plain 302 for links that carry no secret (e.g. "open my board"). |
 | `GET`  | `/health`       | Liveness.                                                        |
@@ -134,3 +146,9 @@ This fixes **addresses changing**. It does not fix `trycloudflare.com` being DNS
 school and corporate networks, because the forward still lands there. For a link that resolves
 everywhere, use a named tunnel on your own domain — RepoYeti supports that directly, and then you
 do not need the relay at all.
+
+## Rollout order
+
+Deploy the Worker with `/oauth/callback` support before releasing a daemon that sends Quick Tunnel
+logins there. No KV migration is required. For rollback, revert the daemon first; the additional
+Worker endpoint is inert and backward-compatible for older daemons.

--- a/relay/README.md
+++ b/relay/README.md
@@ -129,6 +129,9 @@ relay off in Settings deliberately keeps it for that reason.
 Choosing the direct Cloudflare address disables the stable `/r/:id` address, but a Quick Tunnel
 still sends one signed announcement at startup for OAuth return routing. The announcement contains
 only `(id, origin, timestamp, signature)`: no repository names, paths, or share tokens.
+Transient announcement failures are retried by the daemon after 1, 3, and 10 seconds. Retries belong
+to the active tunnel generation: replacing or stopping the tunnel cancels the pending timer, and
+requests to the public `/oauth/login` route never trigger additional KV writes.
 
 ## Endpoints
 

--- a/relay/README.md
+++ b/relay/README.md
@@ -133,15 +133,20 @@ Transient announcement failures are retried by the daemon after 1, 3, and 10 sec
 to the active tunnel generation: replacing or stopping the tunnel cancels the pending timer, and
 requests to the public `/oauth/login` route never trigger additional KV writes.
 
+Successful announcements declare `oauth-callback-v1`. Quick Tunnel OAuth becomes ready only when
+the response that accepted its route contains that capability; an older Worker may keep serving a
+stable `/r/:id` address, but login fails safely before Connections opens. Missing, malformed, and
+unknown capability declarations are terminal and do not consume the transient retry schedule.
+
 ## Endpoints
 
 | Method | Path            | Purpose                                                        |
 | ------ | --------------- | -------------------------------------------------------------- |
-| `POST` | `/announce`     | Daemon publishes its current origin (signed).                    |
+| `POST` | `/announce`     | Publish current origin; success declares protocol capabilities.   |
 | `GET`  | `/oauth/callback` | Resolve relay id from signed state; forward only `code` + `state`. |
 | `GET`  | `/r/:id`        | Forwarding page; re-attaches the URL fragment client-side.       |
 | `GET`  | `/r/:id/<path>` | Plain 302 for links that carry no secret (e.g. "open my board"). |
-| `GET`  | `/health`       | Liveness.                                                        |
+| `GET`  | `/health`       | Liveness and protocol capabilities.                              |
 
 ## Known limit
 
@@ -149,9 +154,3 @@ This fixes **addresses changing**. It does not fix `trycloudflare.com` being DNS
 school and corporate networks, because the forward still lands there. For a link that resolves
 everywhere, use a named tunnel on your own domain — RepoYeti supports that directly, and then you
 do not need the relay at all.
-
-## Rollout order
-
-Deploy the Worker with `/oauth/callback` support before releasing a daemon that sends Quick Tunnel
-logins there. No KV migration is required. For rollback, revert the daemon first; the additional
-Worker endpoint is inert and backward-compatible for older daemons.

--- a/relay/worker.js
+++ b/relay/worker.js
@@ -22,6 +22,12 @@
  * `<currentOrigin>/s/<token>`. So the relay learns that someone opened *a* link for a daemon, and
  * cannot learn the secret or redeem it. That property is structural, not a promise about logging.
  *
+ * OAUTH CALLBACK
+ * The registered `/oauth/callback` also forwards a transient authorization code and signed state
+ * to the announced daemon's `/oauth/finish`. The Worker can observe that code, but cannot redeem it:
+ * the PKCE verifier exists only in daemon memory. It extracts only the relay id from state and
+ * resolves the destination from its signed-announcement KV record, never from a caller-owned URL.
+ *
  * TRUST MODEL — trust on first use, then signatures.
  * The first `/announce` for an id registers its Ed25519 public key. Every later announce for that
  * id must carry a signature verifiable against the stored key, so only the daemon holding the
@@ -52,6 +58,17 @@ function b64urlToBytes(s) {
   const b64 = s.replace(/-/g, "+").replace(/_/g, "/");
   const bin = atob(b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), "="));
   return Uint8Array.from(bin, (ch) => ch.charCodeAt(0));
+}
+
+function relayIdFromState(state) {
+  try {
+    const body = String(state ?? "").split(".")[0];
+    if (!body) return null;
+    const parsed = JSON.parse(new TextDecoder().decode(b64urlToBytes(body)));
+    return ID_RE.test(String(parsed?.r ?? "")) ? String(parsed.r) : null;
+  } catch {
+    return null;
+  }
 }
 
 async function verify(publicKeyB64, signatureB64, payload) {
@@ -160,6 +177,35 @@ export default {
       const target = safeOrigin(JSON.parse(raw).origin);
       if (!target) return json({ ok: false, error: "not found" }, 404);
       return json({ ok: true, origin: target });
+    }
+
+    // ── stable OAuth callback for rotating Quick Tunnels ───────────────────────
+    if (url.pathname === "/oauth/callback" && request.method === "GET") {
+      const code = url.searchParams.get("code");
+      const state = url.searchParams.get("state");
+      const id = relayIdFromState(state);
+      if (!code || !state || !id) return json({ ok: false, error: "bad oauth callback" }, 400);
+
+      const raw = await env.RELAY.get(`d:${id}`);
+      if (!raw) return json({ ok: false, error: "daemon not found" }, 404);
+      let target;
+      try {
+        target = safeOrigin(JSON.parse(raw).origin);
+      } catch {
+        target = null;
+      }
+      if (!target) return json({ ok: false, error: "daemon not found" }, 404);
+
+      const finish = new URL("/oauth/finish", target);
+      finish.searchParams.set("code", code);
+      finish.searchParams.set("state", state);
+      return new Response(null, {
+        status: 302,
+        headers: {
+          location: finish.toString(),
+          "cache-control": "no-store",
+        },
+      });
     }
 
     // ── someone opens a link ──────────────────────────────────────────────────

--- a/relay/worker.js
+++ b/relay/worker.js
@@ -39,6 +39,7 @@
  */
 
 const ID_RE = /^[a-z0-9]{16,64}$/i;
+const CAPABILITIES = ["oauth-callback-v1"];
 /** Reject an announce whose timestamp is far from ours — a captured one can't be replayed later. */
 const MAX_SKEW_MS = 5 * 60 * 1000;
 
@@ -162,7 +163,7 @@ export default {
         `d:${id}`,
         JSON.stringify({ publicKey: key, origin: cleanOrigin, updatedAt: Date.now() }),
       );
-      return json({ ok: true, url: `${url.origin}/r/${id}` });
+      return json({ ok: true, url: `${url.origin}/r/${id}`, capabilities: CAPABILITIES });
     }
 
     // ── resolve a daemon for another RepoYeti installation ─────────────────────
@@ -227,7 +228,7 @@ export default {
       return new Response(forwardPage(target), { headers: html() });
     }
 
-    if (url.pathname === "/health") return json({ ok: true });
+    if (url.pathname === "/health") return json({ ok: true, capabilities: CAPABILITIES });
     return new Response("Not found", { status: 404 });
   },
 };

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,11 +10,10 @@
  * local-only (127.0.0.1) and unauthenticated — safe because nothing can reach it.
  *
  * Flow (daemon-side PKCE; the phone never holds tokens):
- *   /oauth/login → authorize (redirect_uri = <origin>/oauth/callback) with signed state that
- *   embeds this daemon's origin → IdP → <origin>/oauth/callback?code&state → token exchange →
- *   verify id_token (JWKS) → owner check → signed session cookie. The IdP allow-lists the daemon's
- *   OWN callback (app.repoyeti.com/oauth/callback + the loopback); the old rotating-URL "shim" Worker
- *   is retired (see config.ts CONNECTIONS_OAUTH + handleLogin below).
+ *   /oauth/login → authorize with the exact registered redirect URI stored in signed state → IdP →
+ *   callback → /oauth/finish → token exchange with that same redirect URI → verify id_token (JWKS)
+ *   → owner check → signed session cookie. Quick Tunnels use the stable relay callback; loopback and
+ *   other stable origins complete directly on the daemon.
  *
  * Reusable across apps: the OIDC handlers (handleLogin/handleComplete/handleLogout/…) take a bare
  * `OAuthConfig` plus an optional `AuthOptions` bag (cookie names, signing secret, a TOFU-persist
@@ -152,8 +151,8 @@ function clientProto(c: Context): string {
 function isHttps(c: Context): boolean {
   return clientProto(c) === "https";
 }
-/** The daemon's public origin as the browser reached it (https over a tunnel). This
- * is what we stamp into `state` so the shim bounces back to a reachable URL. */
+/** The daemon's public origin as the browser reached it (https over a tunnel). This is signed into
+ * state so the relay return and the final post-login navigation stay bound to the initiating host. */
 function publicOrigin(c: Context): string {
   const u = new URL(c.req.url);
   u.protocol = `${clientProto(c)}:`;
@@ -262,23 +261,41 @@ type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<
 export interface HandleLoginOptions extends AuthOptions {
   /** Override the fetch used for OIDC discovery (lets a unit test avoid a live network). */
   fetchImpl?: FetchLike;
+  /** Resolve the exact registered callback for the browser-visible origin. */
+  resolveRedirect?: (origin: string) => Promise<{ redirectUri: string; relayId?: string }>;
 }
 
 export async function handleLogin(c: Context, oauth: OAuthConfig, opts?: HandleLoginOptions): Promise<Response> {
   const o = oauth;
+  const origin = publicOrigin(c);
+  let resolved: { redirectUri: string; relayId?: string };
+  try {
+    resolved = opts?.resolveRedirect
+      ? await opts.resolveRedirect(origin)
+      : { redirectUri: `${origin}/oauth/callback` };
+  } catch {
+    return c.html(errPage("Remote sign-in is temporarily unavailable. Try again shortly."), 503);
+  }
   const doc = await discover(o.issuer, opts?.fetchImpl ?? authFetch);
   const { verifier, challenge } = pkce();
   const nonce = randomBytes(16).toString("base64url");
   txs.set(nonce, { verifier, ts: Date.now() });
   gcTx();
-  const origin = publicOrigin(c);
-  const state = sign(JSON.stringify({ n: nonce, o: origin }), opts?.secret);
+  const state = sign(
+    JSON.stringify({
+      n: nonce,
+      o: origin,
+      d: resolved.redirectUri,
+      ...(resolved.relayId ? { r: resolved.relayId } : {}),
+    }),
+    opts?.secret,
+  );
   const url = new URL(doc.authorization_endpoint!);
   url.searchParams.set("response_type", "code");
   url.searchParams.set("client_id", o.clientId);
-  // Doing it right (we own the domain): register the daemon's OWN callback at its current origin —
-  // no rotating-URL shim. The IdP allow-lists app.repoyeti.com/oauth/callback + the loopback.
-  url.searchParams.set("redirect_uri", `${origin}/oauth/callback`);
+  // This exact value is signed into state and must be reused by the token exchange. Quick Tunnels
+  // resolve to the stable relay callback; loopback and stable origins use their own callback.
+  url.searchParams.set("redirect_uri", resolved.redirectUri);
   url.searchParams.set("scope", o.scopes || "openid profile email photo");
   url.searchParams.set("code_challenge", challenge);
   url.searchParams.set("code_challenge_method", "S256");
@@ -295,7 +312,7 @@ export interface HandleCompleteOptions extends AuthOptions {
   jwksSet?: Parameters<typeof jwtVerify>[1];
 }
 
-/** Shared by /oauth/finish (shim bounce) and /oauth/callback (loopback). */
+/** Shared by /oauth/finish (stable relay return) and /oauth/callback (direct completion). */
 export async function handleComplete(
   c: Context,
   oauth: OAuthConfig,
@@ -310,10 +327,12 @@ export async function handleComplete(
   if (!sp) return c.html(errPage("Invalid or tampered sign-in state."), 400);
   let nonce: string;
   let stateOrigin: string;
+  let stateRedirectUri: string;
   try {
     const parsed = JSON.parse(sp);
     nonce = parsed.n as string;
     stateOrigin = String(parsed.o || "");
+    stateRedirectUri = String(parsed.d || `${stateOrigin}/oauth/callback`);
   } catch {
     return c.html(errPage("Invalid sign-in state."), 400);
   }
@@ -329,9 +348,9 @@ export async function handleComplete(
     const body = new URLSearchParams({
       grant_type: "authorization_code",
       code,
-      // Must EXACTLY match the redirect_uri sent at /oauth/login — the daemon's own origin (from the
-      // signed state, so it can't be tampered) + /oauth/callback. No shim.
-      redirect_uri: `${stateOrigin}/oauth/callback`,
+      // Must EXACTLY match the redirect_uri sent at /oauth/login. New states carry it explicitly;
+      // old local states fall back to their signed origin + /oauth/callback.
+      redirect_uri: stateRedirectUri,
       client_id: o.clientId,
       code_verifier: tx.verifier,
     });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -240,7 +240,10 @@ export function handleContinueLocal(c: Context, opts?: AuthOptions): Response {
 }
 
 // ── HTML for the auth-complete error page ──────────────────────────────────────
-function errPage(message: string): string {
+function errPage(
+  message: string,
+  action: { href: string; label: string } = { href: "/oauth/login", label: "Try again" },
+): string {
   return `<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>RepoYeti — sign in</title>
 <body style="margin:0;background:#0e0e12;color:#e6e6ea;font-family:system-ui,sans-serif;display:grid;place-items:center;min-height:100vh">
@@ -248,7 +251,7 @@ function errPage(message: string): string {
 <div style="font-size:40px">🔒</div>
 <h2 style="margin:12px 0 8px">Can't sign you in</h2>
 <p style="color:#9a9aa6;font-size:14px;line-height:1.5">${message}</p>
-<a href="/oauth/login" style="display:inline-block;margin-top:14px;background:#3ddc84;color:#06210f;text-decoration:none;font-weight:600;padding:10px 18px;border-radius:9px">Try again</a>
+<a href="${action.href}" style="display:inline-block;margin-top:14px;background:#3ddc84;color:#06210f;text-decoration:none;font-weight:600;padding:10px 18px;border-radius:9px">${action.label}</a>
 </div></body>`;
 }
 
@@ -265,6 +268,12 @@ export interface HandleLoginOptions extends AuthOptions {
   resolveRedirect?: (origin: string) => Promise<{ redirectUri: string; relayId?: string }>;
 }
 
+export class OAuthCallbackUnavailableError extends Error {
+  constructor(readonly exhausted: boolean) {
+    super("Quick Tunnel OAuth callback is unavailable");
+  }
+}
+
 export async function handleLogin(c: Context, oauth: OAuthConfig, opts?: HandleLoginOptions): Promise<Response> {
   const o = oauth;
   const origin = publicOrigin(c);
@@ -273,7 +282,16 @@ export async function handleLogin(c: Context, oauth: OAuthConfig, opts?: HandleL
     resolved = opts?.resolveRedirect
       ? await opts.resolveRedirect(origin)
       : { redirectUri: `${origin}/oauth/callback` };
-  } catch {
+  } catch (error) {
+    if (error instanceof OAuthCallbackUnavailableError && error.exhausted) {
+      return c.html(
+        errPage(
+          "Remote sign-in could not prepare its callback route. Restart RepoYeti and try again.",
+          { href: "/", label: "Return to RepoYeti" },
+        ),
+        503,
+      );
+    }
     return c.html(errPage("Remote sign-in is temporarily unavailable. Try again shortly."), 503);
   }
   const doc = await discover(o.issuer, opts?.fetchImpl ?? authFetch);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -268,8 +268,10 @@ export interface HandleLoginOptions extends AuthOptions {
   resolveRedirect?: (origin: string) => Promise<{ redirectUri: string; relayId?: string }>;
 }
 
+export type OAuthCallbackUnavailableReason = "temporary" | "failed" | "incompatible";
+
 export class OAuthCallbackUnavailableError extends Error {
-  constructor(readonly exhausted: boolean) {
+  constructor(readonly reason: OAuthCallbackUnavailableReason) {
     super("Quick Tunnel OAuth callback is unavailable");
   }
 }
@@ -283,7 +285,16 @@ export async function handleLogin(c: Context, oauth: OAuthConfig, opts?: HandleL
       ? await opts.resolveRedirect(origin)
       : { redirectUri: `${origin}/oauth/callback` };
   } catch (error) {
-    if (error instanceof OAuthCallbackUnavailableError && error.exhausted) {
+    if (error instanceof OAuthCallbackUnavailableError && error.reason === "incompatible") {
+      return c.html(
+        errPage(
+          "The remote sign-in service needs to be updated before this RepoYeti version can authenticate through a Quick Tunnel (missing oauth-callback-v1).",
+          { href: "/", label: "Return to RepoYeti" },
+        ),
+        503,
+      );
+    }
+    if (error instanceof OAuthCallbackUnavailableError && error.reason === "failed") {
       return c.html(
         errPage(
           "Remote sign-in could not prepare its callback route. Restart RepoYeti and try again.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,7 +44,7 @@ export interface OAuthConfig {
   clientId: string;
   /** Only for a confidential client; a public PKCE client omits it. */
   clientSecret?: string;
-  /** Registered redirect URI — the fixed shim URL (Path A) or the loopback (Path B). */
+  /** Registered redirect URI used for rotating Quick Tunnels; stable/loopback origins stay direct. */
   redirectUri: string;
   /** The single owner this daemon admits (match either). */
   ownerSub?: string;
@@ -665,11 +665,10 @@ export function redactAi(cfg: RepoYetiConfig): RedactedAiConfig {
 
 /**
  * The public "Sign in with Connections" OAuth client for RepoYeti, baked in so login works
- * with zero owner setup. These are PUBLIC by nature (a PKCE client — no secret). Now that we own
- * a stable domain, login is done the RIGHT way: the daemon registers its OWN callback at its
- * current origin (`<origin>/oauth/callback`, see src/auth.ts) — the old rotating-URL "shim" Worker
- * is retired. The IdP allow-lists `https://app.repoyeti.com/oauth/callback` + the loopback. This
- * `redirectUri` is now just a presence marker for authEnforced(); auth.ts derives the live value.
+ * with zero owner setup. These are PUBLIC by nature (a PKCE client — no secret). Connections
+ * allow-lists `https://app.repoyeti.com/oauth/callback` plus loopback. Quick Tunnels use that exact
+ * stable callback through the relay; loopback and other stable origins use their own callback.
+ * `redirectUri` is therefore protocol data, not a configuration-presence marker.
  */
 const CONNECTIONS_OAUTH: OAuthConfig = {
   issuer: "https://accounts.connections.icu",
@@ -1000,7 +999,7 @@ export async function hydrateSecrets(cfg: RepoYetiConfig): Promise<void> {
     // The baked-in Connections client is PUBLIC (PKCE is its only proof): AEGIS registers it with
     // token_endpoint_auth_method "none" and no secret hash, and its token endpoint refuses any
     // exchange that PRESENTS a client_secret — with invalid_client, BEFORE it consumes the code, so
-    // every sign-in dies at /oauth/callback while the code sits unspent. The retired GitMob-era shim
+    // every sign-in dies at /oauth/callback while the code sits unspent. The old GitMob callback
     // registered this SAME client_id as confidential, so its secret can still be in the keychain —
     // and getSecret() re-homes it out of the old "gitmob" service, which is how a dead credential
     // reaches a client that must never send one. AEGIS kept no hash to verify it against: it is

--- a/src/http/routes/auth.ts
+++ b/src/http/routes/auth.ts
@@ -12,12 +12,13 @@ import {
   hasLocalBypass,
   type AuthOptions,
   type HandleLoginOptions,
+  OAuthCallbackUnavailableError,
 } from "../../auth.ts";
 import { rememberTokens, clearTokens, pullNow } from "../../connections-sync.ts";
 import { deleteSecret, API_TOKEN } from "../../secrets.ts";
 import { effectiveGuest } from "../../auth.ts";
 import { clearGuestCookie } from "../../share/index.ts";
-import { getOAuthCallback } from "../../runtime.ts";
+import { getOAuthCallback, getOAuthCallbackStatus } from "../../runtime.ts";
 
 export function register(app: Hono, { cfg }: Deps): void {
   // Public: lets the PWA decide whether to show the "Sign in with Connections" screen,
@@ -108,7 +109,9 @@ export function register(app: Hono, { cfg }: Deps): void {
     ...authOpts,
     resolveRedirect: async (origin) => {
       const callback = getOAuthCallback(cfg, origin);
-      if (!callback) throw new Error("Quick Tunnel OAuth callback is not ready");
+      if (!callback) {
+        throw new OAuthCallbackUnavailableError(getOAuthCallbackStatus(cfg, origin) === "failed");
+      }
       return callback;
     },
   };

--- a/src/http/routes/auth.ts
+++ b/src/http/routes/auth.ts
@@ -12,6 +12,7 @@ import {
   hasLocalBypass,
   type AuthOptions,
   type HandleLoginOptions,
+  type OAuthCallbackUnavailableReason,
   OAuthCallbackUnavailableError,
 } from "../../auth.ts";
 import { rememberTokens, clearTokens, pullNow } from "../../connections-sync.ts";
@@ -110,7 +111,10 @@ export function register(app: Hono, { cfg }: Deps): void {
     resolveRedirect: async (origin) => {
       const callback = getOAuthCallback(cfg, origin);
       if (!callback) {
-        throw new OAuthCallbackUnavailableError(getOAuthCallbackStatus(cfg, origin) === "failed");
+        const status = getOAuthCallbackStatus(cfg, origin);
+        const reason: OAuthCallbackUnavailableReason =
+          status === "failed" || status === "incompatible" ? status : "temporary";
+        throw new OAuthCallbackUnavailableError(reason);
       }
       return callback;
     },

--- a/src/http/routes/auth.ts
+++ b/src/http/routes/auth.ts
@@ -11,11 +11,13 @@ import {
   isRemoteRequest,
   hasLocalBypass,
   type AuthOptions,
+  type HandleLoginOptions,
 } from "../../auth.ts";
 import { rememberTokens, clearTokens, pullNow } from "../../connections-sync.ts";
 import { deleteSecret, API_TOKEN } from "../../secrets.ts";
 import { effectiveGuest } from "../../auth.ts";
 import { clearGuestCookie } from "../../share/index.ts";
+import { getOAuthCallback } from "../../runtime.ts";
 
 export function register(app: Hono, { cfg }: Deps): void {
   // Public: lets the PWA decide whether to show the "Sign in with Connections" screen,
@@ -102,11 +104,19 @@ export function register(app: Hono, { cfg }: Deps): void {
       });
     },
   };
+  const loginOpts: HandleLoginOptions = {
+    ...authOpts,
+    resolveRedirect: async (origin) => {
+      const callback = getOAuthCallback(cfg, origin);
+      if (!callback) throw new Error("Quick Tunnel OAuth callback is not ready");
+      return callback;
+    },
+  };
 
   // OIDC dance (only meaningful when configured). oauthGuard guarantees cfg.oauth is present.
   const oauthGuard = (h: (c: Context) => Promise<Response>) => (c: Context) =>
     authEnforced(cfg) ? h(c) : c.text("Sign-in is not configured for this daemon.", 404);
-  app.get("/oauth/login", oauthGuard((c) => handleLogin(c, cfg.oauth!, authOpts)));
+  app.get("/oauth/login", oauthGuard((c) => handleLogin(c, cfg.oauth!, loginOpts)));
   app.get("/oauth/finish", oauthGuard((c) => handleComplete(c, cfg.oauth!, authOpts)));
   app.get("/oauth/callback", oauthGuard((c) => handleComplete(c, cfg.oauth!, authOpts)));
 }

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -18,6 +18,8 @@
  */
 import { createPrivateKey, createPublicKey, generateKeyPairSync, randomBytes, sign } from "node:crypto";
 
+export const OAUTH_CALLBACK_CAPABILITY = "oauth-callback-v1";
+
 /** Public shape of this daemon's relay identity. The private key never leaves this module. */
 export interface RelayIdentity {
   /** Stable, random, 32 hex chars. Appears in every share URL, so it is an identifier, not a secret. */
@@ -80,6 +82,8 @@ export interface AnnounceResult {
   ok: boolean;
   /** The permanent URL this daemon is reachable at, when the relay accepted us. */
   url?: string;
+  /** Optional protocol features declared by the Worker that accepted this announcement. */
+  capabilities?: readonly string[];
   error?: string;
 }
 
@@ -123,9 +127,21 @@ export async function announce(
         publicKey: identity.publicKey,
       }),
     });
-    const body = (await res.json().catch(() => ({}))) as { ok?: boolean; url?: string; error?: string };
+    const body = (await res.json().catch(() => ({}))) as {
+      ok?: boolean;
+      url?: string;
+      capabilities?: unknown;
+      error?: string;
+    };
     if (!res.ok || !body.ok) return { ok: false, error: body.error ?? `relay returned ${res.status}` };
-    return { ok: true, url: body.url ?? `${base}/r/${identity.id}` };
+    const capabilities = Array.isArray(body.capabilities)
+      ? body.capabilities.filter((capability): capability is string => typeof capability === "string")
+      : undefined;
+    return {
+      ok: true,
+      url: body.url ?? `${base}/r/${identity.id}`,
+      ...(capabilities ? { capabilities } : {}),
+    };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -19,6 +19,7 @@ import {
   createRelayIdentity,
   publicKeyFor,
   relayShareUrl,
+  type AnnounceResult,
   type RelayIdentity,
 } from "./relay.ts";
 
@@ -52,11 +53,37 @@ interface OAuthCallbackRoute {
   origin: string;
   redirectUri: string;
   relayId: string;
-  error: string | null;
+  status: "ready" | "retrying" | "failed";
+  error?: string;
 }
 
 let oauthCallbackRoute: OAuthCallbackRoute | null = null;
 let remoteRouteGeneration = 0;
+const OAUTH_CALLBACK_RETRY_DELAYS_MS = [1_000, 3_000, 10_000] as const;
+let pendingRemoteRouteRetry: { timer: ReturnType<typeof setTimeout>; cancel: () => void } | null = null;
+
+export interface PublishRemoteRoutesOptions {
+  retryDelaysMs?: readonly number[];
+}
+
+function cancelRemoteRouteRetry(): void {
+  pendingRemoteRouteRetry?.cancel();
+}
+
+function waitForRemoteRouteRetry(delayMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (retry: boolean): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      pendingRemoteRouteRetry = null;
+      resolve(retry);
+    };
+    const timer = setTimeout(() => finish(true), delayMs);
+    pendingRemoteRouteRetry = { timer, cancel: () => finish(false) };
+  });
+}
 
 function isQuickTunnelOrigin(origin: string): boolean {
   try {
@@ -72,7 +99,9 @@ export async function publishRemoteRoutes(
   cfg: RepoYetiConfig,
   origin: string,
   fetchImpl: typeof fetch = fetch,
+  options: PublishRemoteRoutesOptions = {},
 ): Promise<void> {
+  cancelRemoteRouteRetry();
   const generation = ++remoteRouteGeneration;
   if (!isQuickTunnelOrigin(origin)) {
     oauthCallbackRoute = null;
@@ -92,20 +121,32 @@ export async function publishRemoteRoutes(
   const identity = await ensureRelayIdentity(cfg);
   if (generation !== remoteRouteGeneration) return;
   const sameRelay = relay.enabled && relay.url.replace(/\/+$/, "") === callbackBase;
-  const callbackResult = await announce(callbackBase, identity, origin, fetchImpl);
-  // A stopped or replaced tunnel must not become login-ready just because its older announce
-  // finished last. Only the newest publication attempt may update process-wide route state.
-  if (generation !== remoteRouteGeneration) return;
-  oauthCallbackRoute = {
-    origin,
-    redirectUri,
-    relayId: identity.id,
-    error: callbackResult.ok ? null : (callbackResult.error ?? "announce failed"),
-  };
+  const retryDelays = options.retryDelaysMs ?? OAUTH_CALLBACK_RETRY_DELAYS_MS;
+  let callbackResult: AnnounceResult;
+  for (let attempt = 0; ; attempt++) {
+    callbackResult = await announce(callbackBase, identity, origin, fetchImpl);
+    // A stopped or replaced tunnel must not become login-ready just because its older announce
+    // finished last. Only the newest publication attempt may update process-wide route state.
+    if (generation !== remoteRouteGeneration) return;
+    oauthCallbackRoute = {
+      origin,
+      redirectUri,
+      relayId: identity.id,
+      status: callbackResult.ok
+        ? "ready"
+        : attempt < retryDelays.length
+          ? "retrying"
+          : "failed",
+      ...(callbackResult.ok ? {} : { error: callbackResult.error ?? "announce failed" }),
+    };
+    if (callbackResult.ok || attempt >= retryDelays.length) break;
+    if (!(await waitForRemoteRouteRetry(retryDelays[attempt]!))) return;
+    if (generation !== remoteRouteGeneration) return;
+  }
 
   if (sameRelay) {
     relayAnnounced = callbackResult.ok;
-    relayError = oauthCallbackRoute.error;
+    relayError = oauthCallbackRoute.error ?? null;
     broadcast("daemon_status", {
       relay: redactRelay(cfg),
       relayUrl: getRelayBase(cfg),
@@ -126,7 +167,7 @@ export function getOAuthCallback(
   if (
     oauthCallbackRoute?.origin !== origin ||
     oauthCallbackRoute.redirectUri !== cfg.oauth?.redirectUri ||
-    oauthCallbackRoute.error
+    oauthCallbackRoute.status !== "ready"
   ) {
     return null;
   }
@@ -134,6 +175,20 @@ export function getOAuthCallback(
     redirectUri: oauthCallbackRoute.redirectUri,
     relayId: oauthCallbackRoute.relayId,
   };
+}
+
+export type OAuthCallbackStatus = "ready" | "pending" | "retrying" | "failed";
+
+/** Browser-facing readiness without exposing raw relay errors to an unauthenticated request. */
+export function getOAuthCallbackStatus(cfg: RepoYetiConfig, origin: string): OAuthCallbackStatus {
+  if (!isQuickTunnelOrigin(origin)) return "ready";
+  if (
+    oauthCallbackRoute?.origin !== origin ||
+    oauthCallbackRoute.redirectUri !== cfg.oauth?.redirectUri
+  ) {
+    return "pending";
+  }
+  return oauthCallbackRoute.status;
 }
 
 /**
@@ -287,6 +342,7 @@ export function stopManagedTunnel(): void {
   tunnelHandle = null;
   tunnelStarting = false;
   tunnelUrl = null;
+  cancelRemoteRouteRetry();
   remoteRouteGeneration++;
   oauthCallbackRoute = null;
   // The relay is still pointing at the address we just abandoned, so "registered" is no longer a

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -17,6 +17,7 @@ import { broadcast } from "./bus.ts";
 import {
   announce,
   createRelayIdentity,
+  OAUTH_CALLBACK_CAPABILITY,
   publicKeyFor,
   relayShareUrl,
   type AnnounceResult,
@@ -53,7 +54,7 @@ interface OAuthCallbackRoute {
   origin: string;
   redirectUri: string;
   relayId: string;
-  status: "ready" | "retrying" | "failed";
+  status: "ready" | "retrying" | "failed" | "incompatible";
   error?: string;
 }
 
@@ -125,6 +126,7 @@ export async function publishRemoteRoutes(
   let callbackResult: AnnounceResult;
   for (let attempt = 0; ; attempt++) {
     callbackResult = await announce(callbackBase, identity, origin, fetchImpl);
+    const callbackCompatible = callbackResult.capabilities?.includes(OAUTH_CALLBACK_CAPABILITY) ?? false;
     // A stopped or replaced tunnel must not become login-ready just because its older announce
     // finished last. Only the newest publication attempt may update process-wide route state.
     if (generation !== remoteRouteGeneration) return;
@@ -133,11 +135,17 @@ export async function publishRemoteRoutes(
       redirectUri,
       relayId: identity.id,
       status: callbackResult.ok
-        ? "ready"
+        ? callbackCompatible
+          ? "ready"
+          : "incompatible"
         : attempt < retryDelays.length
           ? "retrying"
           : "failed",
-      ...(callbackResult.ok ? {} : { error: callbackResult.error ?? "announce failed" }),
+      ...(callbackResult.ok
+        ? callbackCompatible
+          ? {}
+          : { error: `relay does not support ${OAUTH_CALLBACK_CAPABILITY}` }
+        : { error: callbackResult.error ?? "announce failed" }),
     };
     if (callbackResult.ok || attempt >= retryDelays.length) break;
     if (!(await waitForRemoteRouteRetry(retryDelays[attempt]!))) return;
@@ -146,7 +154,7 @@ export async function publishRemoteRoutes(
 
   if (sameRelay) {
     relayAnnounced = callbackResult.ok;
-    relayError = oauthCallbackRoute.error ?? null;
+    relayError = callbackResult.ok ? null : (callbackResult.error ?? "announce failed");
     broadcast("daemon_status", {
       relay: redactRelay(cfg),
       relayUrl: getRelayBase(cfg),
@@ -177,7 +185,7 @@ export function getOAuthCallback(
   };
 }
 
-export type OAuthCallbackStatus = "ready" | "pending" | "retrying" | "failed";
+export type OAuthCallbackStatus = "ready" | "pending" | "retrying" | "failed" | "incompatible";
 
 /** Browser-facing readiness without exposing raw relay errors to an unauthenticated request. */
 export function getOAuthCallbackStatus(cfg: RepoYetiConfig, origin: string): OAuthCallbackStatus {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -48,6 +48,94 @@ export async function publishToRelay(cfg: RepoYetiConfig, origin: string): Promi
   });
 }
 
+interface OAuthCallbackRoute {
+  origin: string;
+  redirectUri: string;
+  relayId: string;
+  error: string | null;
+}
+
+let oauthCallbackRoute: OAuthCallbackRoute | null = null;
+let remoteRouteGeneration = 0;
+
+function isQuickTunnelOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return url.protocol === "https:" && url.hostname.toLowerCase().endsWith(".trycloudflare.com");
+  } catch {
+    return false;
+  }
+}
+
+/** Publish every remote route needed by one freshly-created tunnel without per-login writes. */
+export async function publishRemoteRoutes(
+  cfg: RepoYetiConfig,
+  origin: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const generation = ++remoteRouteGeneration;
+  if (!isQuickTunnelOrigin(origin)) {
+    oauthCallbackRoute = null;
+    await publishToRelay(cfg, origin);
+    return;
+  }
+
+  const redirectUri = cfg.oauth?.redirectUri;
+  if (!redirectUri) {
+    oauthCallbackRoute = null;
+    await publishToRelay(cfg, origin);
+    return;
+  }
+
+  const callbackBase = new URL(redirectUri).origin;
+  const relay = relayEffective(cfg);
+  const identity = await ensureRelayIdentity(cfg);
+  if (generation !== remoteRouteGeneration) return;
+  const sameRelay = relay.enabled && relay.url.replace(/\/+$/, "") === callbackBase;
+  const callbackResult = await announce(callbackBase, identity, origin, fetchImpl);
+  // A stopped or replaced tunnel must not become login-ready just because its older announce
+  // finished last. Only the newest publication attempt may update process-wide route state.
+  if (generation !== remoteRouteGeneration) return;
+  oauthCallbackRoute = {
+    origin,
+    redirectUri,
+    relayId: identity.id,
+    error: callbackResult.ok ? null : (callbackResult.error ?? "announce failed"),
+  };
+
+  if (sameRelay) {
+    relayAnnounced = callbackResult.ok;
+    relayError = oauthCallbackRoute.error;
+    broadcast("daemon_status", {
+      relay: redactRelay(cfg),
+      relayUrl: getRelayBase(cfg),
+      relayAnnounced,
+      relayError,
+    });
+  } else if (relay.enabled) {
+    await publishToRelay(cfg, origin);
+  }
+}
+
+/** Exact callback route available for this request origin, or null while its announce is unavailable. */
+export function getOAuthCallback(
+  cfg: RepoYetiConfig,
+  origin: string,
+): { redirectUri: string; relayId?: string } | null {
+  if (!isQuickTunnelOrigin(origin)) return { redirectUri: `${origin}/oauth/callback` };
+  if (
+    oauthCallbackRoute?.origin !== origin ||
+    oauthCallbackRoute.redirectUri !== cfg.oauth?.redirectUri ||
+    oauthCallbackRoute.error
+  ) {
+    return null;
+  }
+  return {
+    redirectUri: oauthCallbackRoute.redirectUri,
+    relayId: oauthCallbackRoute.relayId,
+  };
+}
+
 /**
  * This daemon's relay keypair, minted and persisted on first need.
  *
@@ -180,7 +268,7 @@ export function startManagedTunnel(cfg: RepoYetiConfig, onReady?: (url: string) 
     // a quick tunnel hands out a NEW hostname here, which is exactly when every share link already
     // sent would otherwise go dead. Best-effort and non-blocking — the relay is a convenience, and
     // a failure to reach it must never affect local git management.
-    void publishToRelay(cfg, url);
+    void publishRemoteRoutes(cfg, url);
   };
   const onErr = (msg: string): void => {
     tunnelStarting = false;
@@ -199,6 +287,8 @@ export function stopManagedTunnel(): void {
   tunnelHandle = null;
   tunnelStarting = false;
   tunnelUrl = null;
+  remoteRouteGeneration++;
+  oauthCallbackRoute = null;
   // The relay is still pointing at the address we just abandoned, so "registered" is no longer a
   // true statement about a link that works. Clear it rather than leave a stale green tick.
   resetRelayStatus();

--- a/tests/auth-login.test.ts
+++ b/tests/auth-login.test.ts
@@ -227,6 +227,38 @@ test("login returns 503 before contacting Connections when the Quick Tunnel call
   expect(discoveryCalled).toBe(false);
 });
 
+test("an exhausted Quick Tunnel callback failure tells the owner to restart instead of retrying forever", async () => {
+  const origin = "https://failed-yeti.trycloudflare.com";
+  const cfg: RepoYetiConfig = {
+    roots: [],
+    port: 7171,
+    maxDepth: 6,
+    maxRepos: 200,
+    mode: "remote",
+    relay: { enabled: false },
+    oauth: { ...OAUTH, redirectUri: "https://app.repoyeti.com/oauth/callback" },
+  };
+  await publishRemoteRoutes(
+    cfg,
+    origin,
+    (async () =>
+      new Response(JSON.stringify({ ok: false, error: "stale timestamp" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch,
+    { retryDelaysMs: [] },
+  );
+
+  const res = await createApp(cfg).request(`${origin}/oauth/login`);
+  const body = await res.text();
+
+  expect(res.status).toBe(503);
+  expect(body).toContain("could not prepare its callback route");
+  expect(body).toContain("Restart RepoYeti");
+  expect(body).toContain('href="/"');
+  expect(body).toContain("Return to RepoYeti");
+});
+
 test("RepoYeti's public login route consumes the callback announced for its Quick Tunnel", async () => {
   const cfg: RepoYetiConfig = {
     roots: [],

--- a/tests/auth-login.test.ts
+++ b/tests/auth-login.test.ts
@@ -15,8 +15,13 @@ import { createHash, randomBytes } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
-import { handleLogin, unsign, txs } from "../src/auth.ts";
-import type { OAuthConfig } from "../src/config.ts";
+import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT } from "jose";
+import worker from "../relay/worker.js";
+import { handleComplete, handleLogin, sign, unsign, txs } from "../src/auth.ts";
+import type { OAuthConfig, RepoYetiConfig } from "../src/config.ts";
+import { createApp } from "../src/http/app.ts";
+import { createRelayIdentity, signAnnounce } from "../src/relay.ts";
+import { publishRemoteRoutes } from "../src/runtime.ts";
 
 // ── Temp REPOYETI_HOME so key() writes session.key into a throwaway dir ─────────
 const TEST_HOME = join(tmpdir(), `repoyeti-auth-login-test-${process.pid}`);
@@ -77,7 +82,7 @@ test("handleLogin(bare OAuthConfig) 302s to the authorize endpoint with a valid 
   expect(loc.searchParams.get("client_id")).toBe(CLIENT_ID);
   expect(loc.searchParams.get("scope")).toBe("openid profile email");
   expect(loc.searchParams.get("code_challenge_method")).toBe("S256");
-  // redirect_uri is the daemon's OWN origin as the browser reached it + /oauth/callback (no shim).
+  // Loopback remains direct; only rotating Quick Tunnels need the stable relay callback.
   expect(loc.searchParams.get("redirect_uri")).toBe("http://localhost/oauth/callback");
 
   // The state is signed (default = module key) and carries a nonce registered in txs whose PKCE
@@ -112,4 +117,235 @@ test("handleLogin honours an injected `secret` — the state is signed with it, 
 
   const { n: nonce } = JSON.parse(unsign(state, secret)!) as { n: string };
   txs.delete(nonce);
+});
+
+test("a Quick Tunnel login uses the resolved stable callback and carries its relay route in signed state", async () => {
+  const relayId = "0123456789abcdef0123456789abcdef";
+  const app = new Hono();
+  app.get("/oauth/login", (c) =>
+    handleLogin(c, OAUTH, {
+      fetchImpl: mockDiscovery(),
+      resolveRedirect: async () => ({
+        redirectUri: "https://app.repoyeti.com/oauth/callback",
+        relayId,
+      }),
+    }),
+  );
+
+  const res = await app.request("https://snowy-yeti.trycloudflare.com/oauth/login");
+
+  expect(res.status).toBe(302);
+  const authorize = new URL(res.headers.get("location")!);
+  expect(authorize.searchParams.get("redirect_uri")).toBe("https://app.repoyeti.com/oauth/callback");
+  const state = authorize.searchParams.get("state")!;
+  const payload = JSON.parse(unsign(state)!) as { n: string; o: string; d: string; r: string };
+  expect(payload.o).toBe("https://snowy-yeti.trycloudflare.com");
+  expect(payload.d).toBe("https://app.repoyeti.com/oauth/callback");
+  expect(payload.r).toBe(relayId);
+
+  txs.delete(payload.n);
+});
+
+test("the token exchange reuses the exact registered callback carried by signed state", async () => {
+  const nonce = `redirect-uri-${Date.now()}`;
+  txs.set(nonce, { verifier: "test-verifier", ts: Date.now() });
+  const state = sign(
+    JSON.stringify({
+      n: nonce,
+      o: "https://snowy-yeti.trycloudflare.com",
+      d: "https://app.repoyeti.com/oauth/callback",
+      r: "0123456789abcdef0123456789abcdef",
+    }),
+  );
+  let tokenBody: URLSearchParams | null = null;
+  const fetchImpl = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url === DISCOVERY_URL) return mockDiscovery()(input, init);
+    if (url === `${ISSUER}/oauth/token`) {
+      tokenBody = new URLSearchParams(String(init?.body));
+      return new Response(JSON.stringify({ error: "stop-after-capture" }), { status: 400 });
+    }
+    throw new Error(`[test] unexpected fetch to ${url}`);
+  };
+  const app = new Hono();
+  app.get("/oauth/finish", (c) => handleComplete(c, OAUTH, { fetchImpl }));
+
+  const res = await app.request(
+    `https://snowy-yeti.trycloudflare.com/oauth/finish?code=test-code&state=${encodeURIComponent(state)}`,
+  );
+
+  expect(res.status).toBe(502);
+  expect(tokenBody!.get("redirect_uri")).toBe("https://app.repoyeti.com/oauth/callback");
+  txs.delete(nonce);
+});
+
+test("a legacy local state without a redirect field keeps using its originating callback", async () => {
+  const nonce = `legacy-state-${Date.now()}`;
+  txs.set(nonce, { verifier: "legacy-verifier", ts: Date.now() });
+  const state = sign(JSON.stringify({ n: nonce, o: "http://localhost:7171" }));
+  let tokenBody: URLSearchParams | null = null;
+  const fetchImpl = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url === DISCOVERY_URL) return mockDiscovery()(input, init);
+    if (url === `${ISSUER}/oauth/token`) {
+      tokenBody = new URLSearchParams(String(init?.body));
+      return new Response(JSON.stringify({ error: "stop-after-capture" }), { status: 400 });
+    }
+    throw new Error(`[test] unexpected fetch to ${url}`);
+  };
+  const app = new Hono();
+  app.get("/oauth/callback", (c) => handleComplete(c, OAUTH, { fetchImpl }));
+
+  const res = await app.request(
+    `http://localhost:7171/oauth/callback?code=test-code&state=${encodeURIComponent(state)}`,
+  );
+
+  expect(res.status).toBe(502);
+  expect(tokenBody!.get("redirect_uri")).toBe("http://localhost:7171/oauth/callback");
+  txs.delete(nonce);
+});
+
+test("login returns 503 before contacting Connections when the Quick Tunnel callback is unavailable", async () => {
+  let discoveryCalled = false;
+  const app = new Hono();
+  app.get("/oauth/login", (c) =>
+    handleLogin(c, OAUTH, {
+      fetchImpl: async () => {
+        discoveryCalled = true;
+        throw new Error("discovery must not run");
+      },
+      resolveRedirect: async () => {
+        throw new Error("callback route is not ready");
+      },
+    }),
+  );
+
+  const res = await app.request("https://snowy-yeti.trycloudflare.com/oauth/login");
+
+  expect(res.status).toBe(503);
+  expect(await res.text()).toContain("temporarily unavailable");
+  expect(discoveryCalled).toBe(false);
+});
+
+test("RepoYeti's public login route consumes the callback announced for its Quick Tunnel", async () => {
+  const cfg: RepoYetiConfig = {
+    roots: [],
+    port: 7171,
+    maxDepth: 6,
+    maxRepos: 200,
+    mode: "remote",
+    relay: { enabled: false },
+    oauth: { ...OAUTH, redirectUri: "https://app.repoyeti.com/oauth/callback" },
+  };
+  await publishRemoteRoutes(
+    cfg,
+    "https://snowy-yeti.trycloudflare.com",
+    (async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch,
+  );
+  // Populate the module's discovery cache through the supported fetch seam, keeping this route
+  // assertion fully offline even though createApp deliberately exposes no production fetch knob.
+  const warmup = new Hono();
+  warmup.get("/oauth/login", (c) => handleLogin(c, cfg.oauth!, { fetchImpl: mockDiscovery() }));
+  const warmupRes = await warmup.request("http://127.0.0.1:7171/oauth/login");
+  const warmupState = new URL(warmupRes.headers.get("location")!).searchParams.get("state")!;
+  txs.delete((JSON.parse(unsign(warmupState)!) as { n: string }).n);
+
+  const res = await createApp(cfg).request("https://snowy-yeti.trycloudflare.com/oauth/login");
+
+  expect(res.status).toBe(302);
+  const authorize = new URL(res.headers.get("location")!);
+  expect(authorize.searchParams.get("redirect_uri")).toBe("https://app.repoyeti.com/oauth/callback");
+  const payload = JSON.parse(unsign(authorize.searchParams.get("state")!)!) as { n: string; r?: string };
+  expect(payload.r).toBe(cfg.relay?.identity?.id);
+  txs.delete(payload.n);
+});
+
+test("a remote browser completes login through the stable Worker callback and receives an owner session", async () => {
+  const origin = "https://snowy-yeti.trycloudflare.com";
+  const identity = createRelayIdentity();
+  const kv = new Map<string, string>();
+  const env = {
+    RELAY: {
+      get: async (key: string) => kv.get(key) ?? null,
+      put: async (key: string, value: string) => void kv.set(key, value),
+    },
+  };
+  const ts = Date.now();
+  const announce = await worker.fetch(
+    new Request("https://app.repoyeti.com/announce", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-signature": signAnnounce(identity, origin, ts),
+      },
+      body: JSON.stringify({ id: identity.id, origin, ts, publicKey: identity.publicKey }),
+    }),
+    env,
+  );
+  expect(announce.status).toBe(200);
+
+  const oauth: OAuthConfig = {
+    ...OAUTH,
+    redirectUri: "https://app.repoyeti.com/oauth/callback",
+    ownerSub: "owner-sub",
+    ownerEmail: "owner@example.com",
+  };
+  const login = new Hono();
+  login.get("/oauth/login", (c) =>
+    handleLogin(c, oauth, {
+      fetchImpl: mockDiscovery(),
+      resolveRedirect: async () => ({ redirectUri: oauth.redirectUri, relayId: identity.id }),
+    }),
+  );
+  const loginRes = await login.request(`${origin}/oauth/login`);
+  const authorize = new URL(loginRes.headers.get("location")!);
+  const state = authorize.searchParams.get("state")!;
+
+  const callback = new URL(oauth.redirectUri);
+  callback.searchParams.set("code", "issued-code");
+  callback.searchParams.set("state", state);
+  const callbackRes = await worker.fetch(new Request(callback), env);
+  expect(callbackRes.status).toBe(302);
+
+  const pair = await generateKeyPair("RS256", { extractable: true });
+  const jwk = await exportJWK(pair.publicKey);
+  jwk.kid = "login-key";
+  const idToken = await new SignJWT({ sub: "owner-sub", email: "owner@example.com" })
+    .setProtectedHeader({ alg: "RS256", kid: "login-key" })
+    .setIssuer(ISSUER)
+    .setAudience(CLIENT_ID)
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(pair.privateKey);
+  let exchange: URLSearchParams | null = null;
+  const finishFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url === DISCOVERY_URL) return mockDiscovery()(input, init);
+    if (url === `${ISSUER}/oauth/token`) {
+      exchange = new URLSearchParams(String(init?.body));
+      return new Response(JSON.stringify({ id_token: idToken }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`[test] unexpected fetch to ${url}`);
+  };
+  const finish = new Hono();
+  finish.get("/oauth/finish", (c) =>
+    handleComplete(c, oauth, {
+      fetchImpl: finishFetch,
+      jwksSet: createLocalJWKSet({ keys: [jwk] }),
+    }),
+  );
+
+  const finishRes = await finish.request(callbackRes.headers.get("location")!);
+
+  expect(finishRes.status).toBe(302);
+  expect(finishRes.headers.get("location")).toBe("/");
+  expect(finishRes.headers.get("set-cookie")).toContain("gm_session=");
+  expect(finishRes.headers.get("set-cookie")).toContain("Secure");
+  expect(exchange!.get("redirect_uri")).toBe(oauth.redirectUri);
+  expect(exchange!.get("code_verifier")).toBeTruthy();
 });

--- a/tests/auth-login.test.ts
+++ b/tests/auth-login.test.ts
@@ -259,6 +259,39 @@ test("an exhausted Quick Tunnel callback failure tells the owner to restart inst
   expect(body).toContain("Return to RepoYeti");
 });
 
+test("an incompatible Worker stops before Connections and tells the owner it needs an update", async () => {
+  const origin = "https://legacy-yeti.trycloudflare.com";
+  const cfg: RepoYetiConfig = {
+    roots: [],
+    port: 7171,
+    maxDepth: 6,
+    maxRepos: 200,
+    mode: "remote",
+    relay: { enabled: false },
+    oauth: { ...OAUTH, redirectUri: "https://app.repoyeti.com/oauth/callback" },
+  };
+  await publishRemoteRoutes(
+    cfg,
+    origin,
+    (async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch,
+    { retryDelaysMs: [0, 0, 0] },
+  );
+
+  const res = await createApp(cfg).request(`${origin}/oauth/login`);
+  const body = await res.text();
+
+  expect(res.status).toBe(503);
+  expect(body).toContain("sign-in service needs to be updated");
+  expect(body).toContain("oauth-callback-v1");
+  expect(body).not.toContain("Try again shortly");
+  expect(body).not.toContain("Restart RepoYeti");
+  expect(body).toContain('href="/"');
+  expect(body).toContain("Return to RepoYeti");
+});
+
 test("RepoYeti's public login route consumes the callback announced for its Quick Tunnel", async () => {
   const cfg: RepoYetiConfig = {
     roots: [],
@@ -273,7 +306,7 @@ test("RepoYeti's public login route consumes the callback announced for its Quic
     cfg,
     "https://snowy-yeti.trycloudflare.com",
     (async () =>
-      new Response(JSON.stringify({ ok: true }), {
+      new Response(JSON.stringify({ ok: true, capabilities: ["oauth-callback-v1"] }), {
         headers: { "content-type": "application/json" },
       })) as unknown as typeof fetch,
   );

--- a/tests/relay-route.test.ts
+++ b/tests/relay-route.test.ts
@@ -17,6 +17,8 @@ import {
   shareLinkFor,
   getRelayBase,
   getOAuthCallback,
+  getOAuthCallbackStatus,
+  getRelayStatus,
   publishRemoteRoutes,
 } from "../src/runtime.ts";
 import { createRelayIdentity, publicKeyFor } from "../src/relay.ts";
@@ -170,7 +172,7 @@ test("a direct Quick Tunnel still publishes the stable OAuth callback route once
   let announcedAt = "";
   const fetchImpl = (async (input: string | URL | Request) => {
     announcedAt = String(input);
-    return new Response(JSON.stringify({ ok: true }), {
+    return new Response(JSON.stringify({ ok: true, capabilities: ["oauth-callback-v1"] }), {
       status: 200,
       headers: { "content-type": "application/json" },
     });
@@ -206,6 +208,62 @@ test("a failed Quick Tunnel callback announce leaves remote login unavailable", 
   expect(getOAuthCallback(cfg, "https://offline-yeti.trycloudflare.com")).toBeNull();
 });
 
+test("missing, malformed, or unknown Worker capabilities stop Quick Tunnel OAuth without retries", async () => {
+  const cfg = base({
+    relay: { enabled: false },
+    oauth: {
+      issuer: "https://accounts.connections.icu",
+      clientId: "public-client",
+      redirectUri: "https://app.repoyeti.com/oauth/callback",
+    },
+  });
+  for (const [index, capabilities] of [undefined, { oauth: true }, ["future-capability"]].entries()) {
+    let attempts = 0;
+    const fetchImpl = (async () => {
+      attempts++;
+      return new Response(JSON.stringify({ ok: true, ...(capabilities === undefined ? {} : { capabilities }) }), {
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    const origin = `https://legacy-${index}.trycloudflare.com`;
+
+    await publishRemoteRoutes(cfg, origin, fetchImpl, { retryDelaysMs: [0, 0, 0] });
+
+    expect(attempts).toBe(1);
+    expect(getOAuthCallback(cfg, origin)).toBeNull();
+    expect(getOAuthCallbackStatus(cfg, origin)).toBe("incompatible");
+  }
+});
+
+test("an old Worker can keep the stable address live while Quick Tunnel OAuth stays incompatible", async () => {
+  const identity = createRelayIdentity();
+  const cfg = base({
+    mode: "remote",
+    relay: { enabled: true, url: "https://app.repoyeti.com", identity },
+    oauth: {
+      issuer: "https://accounts.connections.icu",
+      clientId: "public-client",
+      redirectUri: "https://app.repoyeti.com/oauth/callback",
+    },
+  });
+  const origin = "https://stable-legacy.trycloudflare.com";
+
+  await publishRemoteRoutes(
+    cfg,
+    origin,
+    (async () =>
+      new Response(JSON.stringify({ ok: true, url: `https://app.repoyeti.com/r/${identity.id}` }), {
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch,
+    { retryDelaysMs: [0, 0, 0] },
+  );
+  const status = getRelayStatus();
+
+  expect(status.announced).toBe(true);
+  expect(status.error).toBeNull();
+  expect(getOAuthCallbackStatus(cfg, origin)).toBe("incompatible");
+});
+
 test("a transient Quick Tunnel callback failure retries without a daemon restart", async () => {
   const cfg = base({
     relay: { enabled: false },
@@ -223,7 +281,7 @@ test("a transient Quick Tunnel callback failure retries without a daemon restart
           status: 400,
           headers: { "content-type": "application/json" },
         })
-      : new Response(JSON.stringify({ ok: true }), {
+      : new Response(JSON.stringify({ ok: true, capabilities: ["oauth-callback-v1"] }), {
           headers: { "content-type": "application/json" },
         });
   }) as unknown as typeof fetch;
@@ -267,7 +325,7 @@ test("a replaced Quick Tunnel cancels the previous origin's pending callback ret
     cfg,
     "https://new-yeti.trycloudflare.com",
     (async () =>
-      new Response(JSON.stringify({ ok: true }), {
+      new Response(JSON.stringify({ ok: true, capabilities: ["oauth-callback-v1"] }), {
         headers: { "content-type": "application/json" },
       })) as unknown as typeof fetch,
   );

--- a/tests/relay-route.test.ts
+++ b/tests/relay-route.test.ts
@@ -16,6 +16,8 @@ import {
   publicShareOrigin,
   shareLinkFor,
   getRelayBase,
+  getOAuthCallback,
+  publishRemoteRoutes,
 } from "../src/runtime.ts";
 import { createRelayIdentity, publicKeyFor } from "../src/relay.ts";
 import { isStaleOrigin } from "../src/share/index.ts";
@@ -154,6 +156,53 @@ test("GET /api/status carries the redacted relay for the owner, private key abse
   expect(st.relayUrl).toBe(`https://go.example.com/r/${cfg.relay?.identity?.id}`);
   expect(st.relayError).toBeNull();
   expect(body).not.toContain(cfg.relay?.identity?.privateKey ?? "__absent__");
+});
+
+test("a direct Quick Tunnel still publishes the stable OAuth callback route once", async () => {
+  const cfg = base({
+    relay: { enabled: false },
+    oauth: {
+      issuer: "https://accounts.connections.icu",
+      clientId: "public-client",
+      redirectUri: "https://app.repoyeti.com/oauth/callback",
+    },
+  });
+  let announcedAt = "";
+  const fetchImpl = (async (input: string | URL | Request) => {
+    announcedAt = String(input);
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+
+  await publishRemoteRoutes(cfg, "https://snowy-yeti.trycloudflare.com", fetchImpl);
+
+  expect(announcedAt).toBe("https://app.repoyeti.com/announce");
+  expect(getOAuthCallback(cfg, "https://snowy-yeti.trycloudflare.com")).toEqual({
+    redirectUri: "https://app.repoyeti.com/oauth/callback",
+    relayId: cfg.relay?.identity?.id,
+  });
+  expect(redactRelay(cfg).enabled).toBe(false);
+});
+
+test("a failed Quick Tunnel callback announce leaves remote login unavailable", async () => {
+  const cfg = base({
+    relay: { enabled: false },
+    oauth: {
+      issuer: "https://accounts.connections.icu",
+      clientId: "public-client",
+      redirectUri: "https://app.repoyeti.com/oauth/callback",
+    },
+  });
+
+  await publishRemoteRoutes(
+    cfg,
+    "https://offline-yeti.trycloudflare.com",
+    (async () => new Response("unavailable", { status: 503 })) as unknown as typeof fetch,
+  );
+
+  expect(getOAuthCallback(cfg, "https://offline-yeti.trycloudflare.com")).toBeNull();
 });
 
 // ── the origin links are handed out on ─────────────────────────────────────────────

--- a/tests/relay-route.test.ts
+++ b/tests/relay-route.test.ts
@@ -200,9 +200,85 @@ test("a failed Quick Tunnel callback announce leaves remote login unavailable", 
     cfg,
     "https://offline-yeti.trycloudflare.com",
     (async () => new Response("unavailable", { status: 503 })) as unknown as typeof fetch,
+    { retryDelaysMs: [] },
   );
 
   expect(getOAuthCallback(cfg, "https://offline-yeti.trycloudflare.com")).toBeNull();
+});
+
+test("a transient Quick Tunnel callback failure retries without a daemon restart", async () => {
+  const cfg = base({
+    relay: { enabled: false },
+    oauth: {
+      issuer: "https://accounts.connections.icu",
+      clientId: "public-client",
+      redirectUri: "https://app.repoyeti.com/oauth/callback",
+    },
+  });
+  let attempts = 0;
+  const fetchImpl = (async () => {
+    attempts++;
+    return attempts === 1
+      ? new Response(JSON.stringify({ ok: false, error: "stale timestamp" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        })
+      : new Response(JSON.stringify({ ok: true }), {
+          headers: { "content-type": "application/json" },
+        });
+  }) as unknown as typeof fetch;
+
+  await publishRemoteRoutes(cfg, "https://recovered-yeti.trycloudflare.com", fetchImpl, {
+    retryDelaysMs: [0],
+  });
+
+  expect(attempts).toBe(2);
+  expect(getOAuthCallback(cfg, "https://recovered-yeti.trycloudflare.com")).toEqual({
+    redirectUri: "https://app.repoyeti.com/oauth/callback",
+    relayId: cfg.relay?.identity?.id,
+  });
+});
+
+test("a replaced Quick Tunnel cancels the previous origin's pending callback retries", async () => {
+  const cfg = base({
+    relay: { enabled: false },
+    oauth: {
+      issuer: "https://accounts.connections.icu",
+      clientId: "public-client",
+      redirectUri: "https://app.repoyeti.com/oauth/callback",
+    },
+  });
+  let oldAttempts = 0;
+  const oldPublish = publishRemoteRoutes(
+    cfg,
+    "https://old-yeti.trycloudflare.com",
+    (async () => {
+      oldAttempts++;
+      return new Response(JSON.stringify({ ok: false, error: "unavailable" }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch,
+    { retryDelaysMs: [10] },
+  );
+  while (oldAttempts === 0) await new Promise((resolve) => setTimeout(resolve, 0));
+
+  await publishRemoteRoutes(
+    cfg,
+    "https://new-yeti.trycloudflare.com",
+    (async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch,
+  );
+  await oldPublish;
+
+  expect(oldAttempts).toBe(1);
+  expect(getOAuthCallback(cfg, "https://old-yeti.trycloudflare.com")).toBeNull();
+  expect(getOAuthCallback(cfg, "https://new-yeti.trycloudflare.com")).toEqual({
+    redirectUri: "https://app.repoyeti.com/oauth/callback",
+    relayId: cfg.relay?.identity?.id,
+  });
 });
 
 // ── the origin links are handed out on ─────────────────────────────────────────────

--- a/tests/relay-worker.test.ts
+++ b/tests/relay-worker.test.ts
@@ -127,6 +127,64 @@ test("a path after the id is a plain redirect", async () => {
   expect(res.headers.get("location")).toBe("https://one.trycloudflare.com/dashboard");
 });
 
+test("the stable OAuth callback returns the browser to the announced daemon finish route", async () => {
+  const { identity } = await register();
+  const state = `${Buffer.from(JSON.stringify({ r: identity.id })).toString("base64url")}.daemon-hmac`;
+  const callback = new URL("https://relay.example/oauth/callback");
+  callback.searchParams.set("code", "short-lived-code");
+  callback.searchParams.set("state", state);
+  callback.searchParams.set("untrusted", "must-not-forward");
+
+  const res = await worker.fetch(new Request(callback), env);
+
+  expect(res.status).toBe(302);
+  const location = new URL(res.headers.get("location")!);
+  expect(`${location.origin}${location.pathname}`).toBe("https://one.trycloudflare.com/oauth/finish");
+  expect(location.searchParams.get("code")).toBe("short-lived-code");
+  expect(location.searchParams.get("state")).toBe(state);
+  expect(location.searchParams.has("untrusted")).toBe(false);
+  expect(res.headers.get("cache-control")).toBe("no-store");
+});
+
+test("the OAuth callback fails closed when the registered daemon record is corrupt", async () => {
+  const id = "abcdef0123456789";
+  env.RELAY.map.set(`d:${id}`, "not-json");
+  const state = `${Buffer.from(JSON.stringify({ r: id })).toString("base64url")}.daemon-hmac`;
+  const callback = new URL("https://relay.example/oauth/callback");
+  callback.searchParams.set("code", "short-lived-code");
+  callback.searchParams.set("state", state);
+
+  const res = await worker.fetch(new Request(callback), env);
+
+  expect(res.status).toBe(404);
+  expect(res.headers.has("location")).toBe(false);
+});
+
+test("the OAuth callback never redirects for an unresolved relay destination", async () => {
+  const unknownId = "0123456789abcdef0123456789abcdef";
+  const unsafeId = "abcdef0123456789abcdef0123456789";
+  env.RELAY.map.set(
+    `d:${unsafeId}`,
+    JSON.stringify({ publicKey: "x", origin: "http://plaintext.example" }),
+  );
+  const states = [
+    "",
+    "not-base64.daemon-hmac",
+    `${Buffer.from(JSON.stringify({ r: "wrong-shape" })).toString("base64url")}.daemon-hmac`,
+    `${Buffer.from(JSON.stringify({ r: unknownId })).toString("base64url")}.daemon-hmac`,
+    `${Buffer.from(JSON.stringify({ r: unsafeId })).toString("base64url")}.daemon-hmac`,
+  ];
+
+  for (const state of states) {
+    const callback = new URL("https://relay.example/oauth/callback");
+    callback.searchParams.set("code", "short-lived-code");
+    if (state) callback.searchParams.set("state", state);
+    const res = await worker.fetch(new Request(callback), env);
+    expect(res.status).not.toBe(302);
+    expect(res.headers.has("location")).toBe(false);
+  }
+});
+
 test("another RepoYeti can resolve a relay invitation without executing the forwarding page", async () => {
   const { identity } = await register();
   const res = await worker.fetch(new Request(`https://relay.example/resolve/${identity.id}`), env);

--- a/tests/relay-worker.test.ts
+++ b/tests/relay-worker.test.ts
@@ -42,9 +42,21 @@ async function register(identity = createRelayIdentity(), origin = "https://one.
   return { identity, res };
 }
 
+test("health advertises stable OAuth callback support for deployment checks", async () => {
+  const res = await worker.fetch(new Request("https://relay.example/health"), env);
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, capabilities: ["oauth-callback-v1"] });
+});
+
 test("a first announce registers the daemon and pins its key", async () => {
   const { identity, res } = await register();
   expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({
+    ok: true,
+    url: `https://relay.example/r/${identity.id}`,
+    capabilities: ["oauth-callback-v1"],
+  });
   const stored = JSON.parse(env.RELAY.map.get(`d:${identity.id}`)!);
   expect(stored.origin).toBe("https://one.trycloudflare.com");
   expect(stored.publicKey).toBe(identity.publicKey);

--- a/tests/relay.test.ts
+++ b/tests/relay.test.ts
@@ -126,11 +126,19 @@ test("announce sends the id, origin and signature — and nothing else", async (
       body: JSON.parse(String(init.body)),
       sig: new Headers(init.headers).get("x-signature"),
     };
-    return new Response(JSON.stringify({ ok: true, url: "https://relay.example/r/abc" }), { status: 200 });
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        url: "https://relay.example/r/abc",
+        capabilities: ["oauth-callback-v1", 42, null],
+      }),
+      { status: 200 },
+    );
   }) as unknown as typeof fetch;
 
   const res = await announce("https://relay.example/", identity, "https://host.trycloudflare.com/", spy);
   expect(res.ok).toBe(true);
+  expect(res.capabilities).toEqual(["oauth-callback-v1"]);
   expect(seen!.url).toBe("https://relay.example/announce");
   expect(seen!.sig).toBeTruthy();
   // Exactly these four fields. Anything else would be data leaving a self-hosted tool.
@@ -147,6 +155,18 @@ test("a relay failure is reported, never thrown", async () => {
   const res = await announce("https://relay.example", identity, "https://host.trycloudflare.com", boom);
   expect(res.ok).toBe(false);
   expect(res.error).toContain("network down");
+});
+
+test("a legacy announce response remains successful for stable relay publishing", async () => {
+  const identity = createRelayIdentity();
+  const legacyWorker = (async () =>
+    new Response(JSON.stringify({ ok: true, url: "https://relay.example/r/stable" }), {
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+
+  const res = await announce("https://relay.example", identity, "https://named.example.com", legacyWorker);
+
+  expect(res).toEqual({ ok: true, url: "https://relay.example/r/stable" });
 });
 
 test("the share token rides in the fragment, never the path", () => {


### PR DESCRIPTION
Fixes #13.

## Summary

This PR implements owner authentication through Cloudflare Quick Tunnels by routing OAuth responses through the registered callback:

```text
https://app.repoyeti.com/oauth/callback
```

> [!IMPORTANT]
> This change requires the updated relay Worker to be published at `app.repoyeti.com`.
>
> The Worker currently published there accepts daemon announcements but returns `404 Not Found` for `/oauth/callback`. Because I do not have access to publish the RepoYeti Worker, I could not complete a live end-to-end login.
>
> The complete journey passes in automated integration tests, but a maintainer with the appropriate access will need to make the compatible Worker available through the project's preferred deployment process before the hosted flow can be validated.

The callback resolves the daemon's currently announced Quick Tunnel origin and forwards the OAuth response to `/oauth/finish`.

This applies to both RepoYeti stable addresses and direct `*.trycloudflare.com` access. Loopback and named tunnel behavior remain unchanged.

## What changed

- Added `GET /oauth/callback` to the relay Worker.
- Added the relay ID and effective redirect URI to the daemon-signed OAuth state.
- Reused the exact same redirect URI during authorization and token exchange.
- Added PKCE-protected forwarding from the stable callback to `/oauth/finish`.
- Announced the OAuth callback route when starting any Quick Tunnel, including direct Cloudflare address mode.
- Added bounded retries for transient announcement failures.
- Added `oauth-callback-v1` capability negotiation between the daemon and Worker.
- Added a safe `503` response when the published Worker does not support the callback or the announcement is not ready.
- Preserved compatibility with legacy local OAuth states.
- Kept stable `/r/<id>` addresses independent from the OAuth capability requirement.
- Updated the relevant architecture and remote-access documentation.

## Compatibility behavior

A Worker that accepts an announcement without returning the `oauth-callback-v1` capability is treated as incompatible for Quick Tunnel OAuth.

RepoYeti then returns a clear `503` response before redirecting the browser to Connections, avoiding an OAuth flow that cannot complete.

Transient announcement failures continue to use bounded retries. Capability incompatibility is terminal and does not consume those retries.

## Security considerations

The Worker:

- resolves only relay IDs associated with HTTPS origins registered through the existing Ed25519-signed announcement mechanism;
- does not accept an arbitrary destination from the OAuth state;
- forwards only `code` and `state`;
- returns `Cache-Control: no-store`;
- fails without redirecting when the state, relay ID, or destination is invalid.

The Worker can observe the transient authorization code while forwarding it, but cannot redeem it because the PKCE `code_verifier` remains exclusively with the daemon.

No KV migration or identity format change is required.

## Validation

Automated coverage includes:

- stable callbacks for Quick Tunnels;
- direct Cloudflare address mode;
- unchanged loopback behavior;
- Worker callback validation and parameter filtering;
- unknown, malformed, and non-HTTPS destinations;
- exact redirect URI reuse during token exchange;
- legacy local OAuth states;
- pending, failed, and incompatible announcements;
- transient announcement recovery;
- capability negotiation;
- stable addresses with older Workers;
- the complete simulated login journey through the Worker callback.

Validation completed successfully:

- Relevant backend suite: 117 tests passed.
- OAuth login checkpoint: 10 tests passed.
- `bun run test`
- `bun run typecheck`
- `bun run check`
- `bun run check:coverage`
- `cd web && bun run i18n:check`
- `cd web && bun run test`
- `cd web && bun run build`

## Live validation status

The real Connections authorization flow was confirmed up to its return to the registered callback.

The remaining hosted path could not be tested because the currently published Worker does not yet provide `/oauth/callback`. No Worker deployment was performed as part of this contribution.